### PR TITLE
Add .travis.yml and add gofmt check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+sudo: false
+
+go:
+  - "1.13"
+
+script:
+  - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi


### PR DESCRIPTION
This adds a travis CI check that all go code is formatted according to the `gofmt` command.