### PR TITLE
changed ticker symbols for goerli and rinkeby testnets

### DIFF
--- a/ops/nonvoting_testnet/conf/provider1/currency.toml
+++ b/ops/nonvoting_testnet/conf/provider1/currency.toml
@@ -1,4 +1,4 @@
-Ticker = "ETH"
+Ticker = "GOR"
 RPCUser = "rpcuser"
 RPCPass = "rpcpassword"
 RPCURL = "http://172.28.1.10:9545"

--- a/ops/nonvoting_testnet/conf/provider1/katzenpost.toml
+++ b/ops/nonvoting_testnet/conf/provider1/katzenpost.toml
@@ -100,8 +100,8 @@ AdvertiseUserRegistrationHTTPAddresses = ["http://127.0.0.1:36968"]
 
   [[Provider.CBORPluginKaetzchen]]
     Disable = false
-    Capability = "eth"
-    Endpoint = "+eth"
+    Capability = "gor"
+    Endpoint = "+gor"
     Command = "/go/bin/Meson"
     MaxConcurrency = 1
     [Provider.CBORPluginKaetzchen.Config]

--- a/ops/nonvoting_testnet/conf/provider2/currency.toml
+++ b/ops/nonvoting_testnet/conf/provider2/currency.toml
@@ -1,4 +1,4 @@
-Ticker = "ETH"
+Ticker = "RIN"
 RPCUser = "rpcuser"
 RPCPass = "rpcpassword"
 RPCURL = "http://172.28.1.11:9545"

--- a/ops/nonvoting_testnet/conf/provider2/katzenpost.toml
+++ b/ops/nonvoting_testnet/conf/provider2/katzenpost.toml
@@ -80,8 +80,8 @@ AdvertiseUserRegistrationHTTPAddresses = ["http://127.0.0.1:36967"]
 
   [[Provider.CBORPluginKaetzchen]]
     Disable = false
-    Capability = "eth"
-    Endpoint = "+eth"
+    Capability = "rin"
+    Endpoint = "+rin"
     Command = "/go/bin/Meson"
     MaxConcurrency = 1
     [Provider.CBORPluginKaetzchen.Config]


### PR DESCRIPTION
Currently, both providers' `currency.toml` configuration pointed to the same ticker `ETH` and subsequently, their respective server configuration use this for both `capability` and `endpoint`. However, this is use for the provider to properly route a packet to the correct blockchain. So, in our case, I believe this would give use some form of non-deterministic or error prone behavior since there are 2 `ETH` services that point to different blockchains, namely Goerli and Rinkeby. So, I changed it to their respective ticker symbols gotten from [this list](https://github.com/ethereum-lists/chains/tree/master/_data/chains)