### PR TITLE
Upgrade to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
   - make up
   - make test-client
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+      make push-tags;
+    fi
+
 cache:
   directories:
     - $GOPATH/pkg/mod

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,12 @@ go:
 
 script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
-  - make up
+  - make up && sleep 20
   - make test-client
 
 after_success:
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-      make push-tags;
-    fi
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - make push-tags
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: go
 
-sudo: true
-
-env:
-  - DOCKER_COMPOSE_VERSION=1.24.1
-
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 services:
   docker
 
@@ -19,14 +8,14 @@ go:
 
 script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
-  - make up && sleep 20
+  - make up && sleep 30
   - make test-client
 
 after_success:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make push-tags
+  - make push
 
 cache:
   directories:
-    - $GOPATH/pkg/mod
+    - $GOPATH/pkg
     - /tmp/gopath-pkg

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,47 @@
 flags=.makeFlags
 VPATH=$(flags)
 $(shell mkdir -p $(flags))
-gethVersion=v1.9.8
 dockerRepo=hashcloak
-katzenServer=$(dockerRepo)/katzenpost-server
-katzenAuth=$(dockerRepo)/katzenpost-auth
 katzenBranch=master
+katzenServer=$(dockerRepo)/katzenpost-server:$(katzenBranch)
+katzenAuth=$(dockerRepo)/katzenpost-auth:$(katzenBranch)
+gethVersion=v1.9.9
 gethImage=$(dockerRepo)/client-go:$(gethVersion)
 mesonServer=$(dockerRepo)/meson
 mesonClient=$(dockerRepo)/meson-client
 
 GIT_HASH := $(shell git log --format='%h' -n1)
-BRANCH := $(shell git log --format='%D' -n1 | cut -d'/' -f2)
+TRAVIS_BRANCH ?= $(shell git log --format='%D' -n1 | cut -d'/' -f2)
+BRANCH=$(TRAVIS_BRANCH)
 
-.PHONY:up down
-
-all: hashcloak-geth katzenpost-server meson katzenpost-nonvoting-authority
+.PHONY: up down
 
 clean:
 	rm -rf /tmp/server
 	rm -rf /tmp/authority
 	rm -rf /tmp/Meson
-	rm -rf .makeFlags
+	rm -rf $(flags)
 
 clean-data:
+	rm -r $(flags)/permits
 	rm -rf ./ops/nonvoting_testnet/conf/provider?
 	rm -rf ./ops/nonvoting_testnet/conf/mix?
 	rm -rf ./ops/nonvoting_testnet/conf/auth
 	git checkout ./ops/nonvoting_testnet/conf
 	$(MAKE) permits
 
-
 pull: pull-tags
 
-pull-tags:
-	docker pull '$(katzenServer):$(BRANCH)'
-	docker pull '$(katzenAuth):$(BRANCH)'
-	docker pull '$(mesonServer):$(BRANCH)'
+pull-tags: pull-katzen-server
+	docker pull $(katzenAuth) && echo "success!" || $(MAKE) katzenpost-nonvoting-authority
+	docker pull $(gethImage) && echo "success!" || $(MAKE) hashcloak-geth
 
-push-tags: katzenpost-server katzenpost-nonvoting-authority meson
-	docker push '$(katzenServer):$(katzenBranch)'
-	docker push '$(katzenAuth):$(katzenBranch)'
+pull-katzen-server:
+	docker pull $(katzenServer) && echo "success!" || $(MAKE) katzenpost-server
+
+push-tags: build-images
+	docker push $(katzenServer)
+	docker push $(katzenAuth)
 	docker push '$(mesonServer):$(BRANCH)'
 	docker push $(gethImage)
 
@@ -48,27 +49,27 @@ build-images: hashcloak-geth katzenpost-server katzenpost-nonvoting-authority me
 
 hashcloak-geth:
 	sed -i 's|%%GETH_VERSION%%|$(gethVersion)|g' ./ops/geth.Dockerfile
-	docker build -f ./ops/geth.Dockerfile -t $(dockerRepo)/$(gethImage):$(gethVersion) .
+	docker build -f ./ops/geth.Dockerfile -t $(gethImage) .
 	sed -i 's|$(gethVersion)|%%GETH_VERSION%%|g' ./ops/geth.Dockerfile
 	@touch $(flags)/$@
 
 katzenpost-server:
 	git clone https://github.com/katzenpost/server /tmp/server || true
-	docker build -f /tmp/server/Dockerfile -t $(katzenServer):$(katzenBranch) /tmp/server
+	docker build -f /tmp/server/Dockerfile -t $(katzenServer) /tmp/server
 	@touch $(flags)/$@
 
 katzenpost-nonvoting-authority:
 	git clone https://github.com/katzenpost/authority /tmp/authority || true
-	docker build -f /tmp/authority/Dockerfile.nonvoting -t $(katzenAuth):$(katzenBranch) /tmp/authority
+	docker build -f /tmp/authority/Dockerfile.nonvoting -t $(katzenAuth) /tmp/authority
 	@touch $(flags)/$@
 
-meson: katzenpost-server
-	sed -i 's|%%KATZEN_SERVER%%|$(katzenServer):$(katzenBranch)|g' ./plugin/Dockerfile
+meson: pull-katzen-server hashcloak-geth
+	sed -i 's|%%KATZEN_SERVER%%|$(katzenServer)|g' ./plugin/Dockerfile
 	docker build -f ./plugin/Dockerfile -t $(mesonServer):$(BRANCH) ./plugin
-	sed -i 's|$(katzenServer):$(katzenBranch)|%%KATZEN_SERVER%%|g' ./plugin/Dockerfile
+	sed -i 's|$(katzenServer)|%%KATZEN_SERVER%%|g' ./plugin/Dockerfile
 	@touch $(flags)/$@
 
-up: permits up-nonvoting
+up: permits pull meson up-nonvoting
 
 permits:
 	sudo chmod -R 700 ops/nonvoting_testnet/conf/provider?
@@ -76,11 +77,12 @@ permits:
 	sudo chmod -R 700 ops/nonvoting_testnet/conf/auth
 	@touch $(flags)/$@
 
-up-nonvoting: pull
-	GETH_VERSION=$(gethVersion) \
-	KATZEN_SERVER=$(katzenpost)\
+up-nonvoting:
+	GETH_IMAGE=$(gethImage) \
+	KATZEN_SERVER=$(katzenServer) \
+	KATZEN_AUTH=$(katzenAuth) \
+	MESON_IMAGE=$(mesonServer):$(BRANCH) \
 	docker-compose -f ./ops/nonvoting_testnet/docker-compose.yml up -d
-	@touch $(flags)/$@
 
 down:
 	docker-compose -f ./ops/nonvoting_testnet/docker-compose.yml down
@@ -97,3 +99,9 @@ test-client:
 		-w /client \
 		golang:buster \
 		/bin/bash -c "GORACE=history_size=7 go test -race"
+
+failure:
+	false && ([ $$? -eq 0 ] && echo "success!") || echo "failure"
+
+success:
+	true && ([ $$? -eq 0 ] && echo "success!") || echo "failure!"     

--- a/ops/nonvoting_testnet/docker-compose.yml
+++ b/ops/nonvoting_testnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   goerli:
-    image: hashcloak/client-go:${GETH_VERSION}
+    image: ${GETH_IMAGE}
     environment:
       - "CHAIN=goerli"
     ports:
@@ -16,7 +16,7 @@ services:
         ipv4_address: 172.28.1.10
 
   rinkeby:
-    image: hashcloak/client-go:${GETH_VERSION}
+    image: ${GETH_IMAGE}
     environment:
       - "CHAIN=rinkeby"
     ports:
@@ -31,7 +31,7 @@ services:
 
   provider1:
     restart: unless-stopped
-    image: hashcloak/meson
+    image: ${MESON_IMAGE}
     volumes:
       - ./conf/provider1:/conf
     command: /go/bin/server -f /conf/katzenpost.toml
@@ -46,7 +46,7 @@ services:
 
   provider2:
     restart: unless-stopped
-    image: hashcloak/meson
+    image: ${MESON_IMAGE}
     volumes:
       - ./conf/provider2:/conf
     command: /go/bin/server -f /conf/katzenpost.toml
@@ -62,7 +62,7 @@ services:
 
   mix1:
     restart: unless-stopped
-    image: katzenpost/server
+    image: ${KATZEN_SERVER}
     volumes:
       - ./conf/mix1:/conf
     command: /go/bin/server -f /conf/katzenpost.toml
@@ -76,7 +76,7 @@ services:
 
   mix2:
     restart: unless-stopped
-    image: katzenpost/server
+    image: ${KATZEN_SERVER}
     volumes:
       - ./conf/mix2:/conf
     command: /go/bin/server -f /conf/katzenpost.toml
@@ -90,7 +90,7 @@ services:
 
   mix3:
     restart: unless-stopped
-    image: katzenpost/server
+    image: ${KATZEN_SERVER}
     volumes:
       - ./conf/mix3:/conf
     command: /go/bin/server -f /conf/katzenpost.toml
@@ -104,7 +104,7 @@ services:
 
   auth:
     restart: unless-stopped
-    image: katzenpost/nonvoting_authority
+    image: ${KATZEN_AUTH}
     volumes:
       - ./conf/auth:/conf
     command: /go/bin/nonvoting -f /conf/authority.toml

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -13,15 +13,9 @@ WORKDIR /go/Meson
 COPY . .
 RUN go build -o Meson cmd/main.go 
 
-FROM katzenpost/server
+FROM %%KATZEN_SERVER%%
 
 COPY --from=builder /go/Meson/Meson /go/bin/Meson
-
-# Expose the application port
-# EXPOSE 8181
-
-# create a volume for the configuration persistence
-VOLUME /conf
 
 # This form of ENTRYPOINT allows the process to catch signals from the `docker stop` command
 ENTRYPOINT /go/bin/server -f /conf/katzenpost.toml


### PR DESCRIPTION
This PR has a lot of workflow changes in regards to how docker images are managed, pulled and pushed on both the local and on the docker registry of hub.docker.com.

New containers:
   - `hashcloak/katzenpost-server`: Tags follow the abbreviated commit hash of the katzenpost/server repository.
   - `hashcloak/katzenpost-authority`: Tags follow the abbreviated commit hash of the katzenpost/authority repository.
   - `hashcloak/client-go`: Tags follow a determined version in the [Makefile](https://github.com/hashcloak/Meson/pull/51/files#diff-b67911656ef5d18c4ae36cb6741b7965R18)
   - `hashcloak/meson`: Tags follow the branch name

Make rule behaviors:
 - `pull`: Will pull the tags that correspond to the latest commit on the `master` branch of the `katzenpost/server` and `katzenpost/authority`. If the latest commit from the repository is not present locally then it will build the docker iamges with the latest commit hash.
- `push`: Will build a new container if the container tag is not in the regsitry

Compose file changes:
- Now requires the environment variables of `$KATZEN_AUTH`, `$KATZEN_SERVER`, `$MESON_IMAGE` and `$GETH_IMAGE` to be set for it to run to properly.