### PR TITLE
WIP Entry scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ go:
 
 script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
-  - make up && sleep 30
-  - make test-client
-  - make down
-  - make up-dynamic && sleep 30
+  - make up-dynamic && sleep 20
   - make test-client
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 
 script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
-  - make up-dynamic && sleep 20
+  - make up-dynamic && sleep 30
   - make test-client
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ script:
   - if [ -n "$(gofmt -l ./plugin)" ]; then echo "Go code is not formatted:"; gofmt -d ./plugin; exit 1; fi
   - make up && sleep 30
   - make test-client
+  - make down
+  - make up-dynamic && sleep 30
+  - make test-client
 
 after_success:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ gethImage=$(dockerRepo)/client-go:$(gethVersion)
 mesonServer=$(dockerRepo)/meson
 hashcloakAuth=$(dockerRepo)/authority
 
-messagePush="LOG: Image already exists in docker.io/$(repoRepo). Not pushing: "
+messagePush="LOG: Image already exists in docker.io/$(dockerRepo). Not pushing: "
 messagePull="LOG: success in pulling image: "
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ $(shell mkdir -p $(flags))
 
 dockerRepo=hashcloak
 katzenServerRepo=https://github.com/katzenpost/server
-katzenServerTag=$(shell git ls-remote --heads $(katzenServerRepo) | grep master | cut -c1-7)
+katzenservertag=$(shell git ls-remote --heads $(katzenserverrepo) | grep master | cut -c1-7)
 katzenServer=$(dockerRepo)/katzenpost-server:$(katzenServerTag)
 
 katzenAuthRepo=https://github.com/katzenpost/authority
 katzenAuthTag=$(shell git ls-remote --heads $(katzenAuthRepo) | grep master | cut -c1-7)
+katzenAuthTag=1c00188
 katzenAuth=$(dockerRepo)/katzenpost-auth:$(katzenAuthTag)
 
 gethVersion=v1.9.9
@@ -137,3 +138,9 @@ test-client:
 		golang:buster \
 		/bin/bash -c "GORACE=history_size=7 go test -race"
 	if [ ${CI} ];then sudo chown ${USER} -R /tmp/gopath-pkg;  fi
+
+r: down
+	rm $(flags)/build-meson
+	rm $(flags)/build-hashcloak-nonvoting-authority
+	make up-dynamic
+

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,26 @@
 GIT_HASH := $(shell git log --format='%h' -n1)
-TRAVIS_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
-BRANCH=$(TRAVIS_BRANCH)
+TRAVIS_PULL_REQUEST_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
+BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
 
 flags=.makeFlags
 VPATH=$(flags)
 $(shell mkdir -p $(flags))
-dockerRepo=hashcloak
 
+dockerRepo=hashcloak
 katzenServerRepo=https://github.com/katzenpost/server
 katzenServerTag=$(shell git ls-remote --heads $(katzenServerRepo) | grep master | cut -c1-7)
 katzenServer=$(dockerRepo)/katzenpost-server:$(katzenServerTag)
 
 katzenAuthRepo=https://github.com/katzenpost/authority
-katzenAuthTag=$(shell git ls-remote --heads https://github.com/katzenpost/authority  | grep master | cut -c1-7)
+katzenAuthTag=$(shell git ls-remote --heads $(katzenAuthRepo) | grep master | cut -c1-7)
 katzenAuth=$(dockerRepo)/katzenpost-auth:$(katzenAuthTag)
 
 gethVersion=v1.9.9
 gethImage=$(dockerRepo)/client-go:$(gethVersion)
 mesonServer=$(dockerRepo)/meson
-mesonClient=$(dockerRepo)/meson-client
+hashcloakAuth=$(dockerRepo)/authority
 
-messagePush="LOG: Image already exists in docker.io/$(repo). Not pushing: "
+messagePush="LOG: Image already exists in docker.io/$(repoRepo). Not pushing: "
 messagePull="LOG: success in pulling image: "
 
 clean:
@@ -39,57 +39,65 @@ clean-data:
 pull:
 	docker pull $(katzenAuth) \
 		&& echo $(messagePull)$(katzenAuth) \
-		|| $(MAKE) build-katzenpost-nonvoting-authority
+		|| $(MAKE) build-katzen-nonvoting-authority
 	docker pull $(katzenServer) \
 		&& echo $(messagePull)$(katzenServer) \
-		|| $(MAKE) build-katzenpost-server
+		|| $(MAKE) build-katzen-server
 	docker pull $(gethImage) \
 		&& echo $(messagePull)$(gethImage) \
 		|| $(MAKE) build-geth
+	@touch $(flags)/$@
 
-push: push-katzen-server push-katzen-auth push-geth push-meson
+push: push-katzen-server push-katzen-auth push-geth push-meson push-hashcloak-nonvoting-auth
 
 push-katzen-server:
 	docker pull $(katzenServer) \
 		&& echo $(messagePush)$(katzenServer) \
-		|| ($(MAKE) build-katzenpost-server && docker push $(katzenServer))
+		|| ($(MAKE) build-katzen-server && docker push $(katzenServer))
 
 push-katzen-auth:
 	docker pull $(katzenAuth) \
 		&& echo $(messagePush)$(katzenAuth) \
-		|| ($(MAKE) build-katzenpost-nonvoting-authority && docker push $(katzenAuth))
+		|| ($(MAKE) build-katzen-nonvoting-authority && docker push $(katzenAuth))
 
 push-geth:
 	docker pull $(gethImage) \
 		&& echo $(messagePush)$(gethImage) \
 		|| ($(MAKE) build-geth && docker push $(gethImage))
 
+push-hashcloak-nonvoting-auth: build-hashcloak-nonvoting-authority
+	docker push '$(hashcloakAuth):$(BRANCH)'
+
+
 push-meson: build-meson
 	docker push '$(mesonServer):$(BRANCH)'
 
-build: build-geth build-katzenpost-server build-katzenpost-nonvoting-authority build-meson
+build: build-geth build-katzen-server build-katzen-nonvoting-authority build-meson build-hashcloak-nonvoting-authority
 
 build-geth:
 	sed 's|%%GETH_VERSION%%|$(gethVersion)|g' ./ops/geth.Dockerfile > /tmp/geth.Dockerfile
 	docker build -f /tmp/geth.Dockerfile -t $(gethImage) .
 	@touch $(flags)/$@
 
-build-katzenpost-server:
+build-katzen-server:
 	git clone $(katzenServerRepo) /tmp/server || true
 	docker build -f /tmp/server/Dockerfile -t $(katzenServer) /tmp/server
 	@touch $(flags)/$@
 
-build-katzenpost-nonvoting-authority:
+build-katzen-nonvoting-authority:
 	git clone $(katzenAuthRepo) /tmp/authority || true
 	docker build -f /tmp/authority/Dockerfile.nonvoting -t $(katzenAuth) /tmp/authority
 	@touch $(flags)/$@
 
 build-meson: pull
-	sed 's|%%KATZEN_SERVER%%|$(katzenServer)|g' ./plugin/Dockerfile > /tmp/meson.Dockerfile
-	docker build -f /tmp/meson.Dockerfile -t $(mesonServer):$(BRANCH) ./plugin
+	sed 's|%%KATZEN_SERVER%%|$(katzenServer)|g' ./ops/meson.Dockerfile > /tmp/meson.Dockerfile
+	docker build -f /tmp/meson.Dockerfile -t $(mesonServer):$(BRANCH) .
 	@touch $(flags)/$@
 
-up: permits pull build-meson up-nonvoting
+build-hashcloak-nonvoting-authority: pull
+	sed 's|%%KATZENPOST_AUTH%%|$(katzenAuth)|g' ./ops/auth.nonvoting.Dockerfile > /tmp/auth.nonvoting.Dockerfile
+	docker build -f /tmp/auth.nonvoting.Dockerfile -t $(hashcloakAuth):$(BRANCH) ./ops
+	@touch $(flags)/$@
 
 permits:
 	sudo chmod -R 700 ops/nonvoting_testnet/conf/provider?
@@ -97,23 +105,30 @@ permits:
 	sudo chmod -R 700 ops/nonvoting_testnet/conf/auth
 	@touch $(flags)/$@
 
-up-nonvoting:
+up: permits build-meson build-hashcloak-nonvoting-authority up-nonvoting
 	GETH_IMAGE=$(gethImage) \
 	KATZEN_SERVER=$(katzenServer) \
 	KATZEN_AUTH=$(katzenAuth) \
 	MESON_IMAGE=$(mesonServer):$(BRANCH) \
 	docker-compose -f ./ops/nonvoting_testnet/docker-compose.yml up -d
 
+up-dynamic: build-meson build-hashcloak-nonvoting-authority
+	GETH_IMAGE=$(gethImage) \
+	AUTHORITY_IMAGE=$(hashcloakAuth):$(BRANCH) \
+	MESON_IMAGE=$(mesonServer):$(BRANCH) \
+	docker-compose -f ./ops/dynamic-testnet.yml up -d
+
 down:
 	docker-compose -f ./ops/nonvoting_testnet/docker-compose.yml down
+	docker-compose -f ./ops/dynamic-testnet.yml down
 
 test-client:
 	git clone https://github.com/hashcloak/Meson-client /tmp/Meson-client || true
 	docker run \
 		-v /tmp/Meson-client:/client \
 		-v /tmp/gopath-pkg:/go/pkg \
-		--network nonvoting_testnet_nonvoting_test_net \
+		--network $(shell docker network ls --format '{{.Name}}' | grep testnet) \
 		-w /client \
 		golang:buster \
 		/bin/bash -c "GORACE=history_size=7 go test -race"
-	[ ${CI} ]; sudo chown ${USER} -R /tmp/gopath-pkg
+	if [ ${CI} ];then sudo chown ${USER} -R /tmp/gopath-pkg;  fi

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 TRAVIS_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
+
 BRANCH=$(TRAVIS_BRANCH)
-TRAVIS_PULL_REQUEST_BRANCH ?= ""
-ifneq ($(TRAVIS_PULL_REQUEST_BRANCH), "")
-	BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
-endif
+
+#TRAVIS_PULL_REQUEST_BRANCH ?= ""
+#ifneq ($(TRAVIS_PULL_REQUEST_BRANCH), "")
+	#BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
+#endif
 
 flags=.makeFlags
 VPATH=$(flags)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-GIT_HASH := $(shell git log --format='%h' -n1)
-TRAVIS_PULL_REQUEST_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
-BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
+TRAVIS_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
+BRANCH=$(TRAVIS_BRANCH)
+TRAVIS_PULL_REQUEST_BRANCH ?= ""
+ifneq ($(TRAVIS_PULL_REQUEST_BRANCH), "")
+	BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
+endif
 
 flags=.makeFlags
 VPATH=$(flags)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 TRAVIS_BRANCH ?= $(shell git branch| grep \* | cut -d' ' -f2)
-
 BRANCH=$(TRAVIS_BRANCH)
 
-#TRAVIS_PULL_REQUEST_BRANCH ?= ""
-#ifneq ($(TRAVIS_PULL_REQUEST_BRANCH), "")
-	#BRANCH=$(TRAVIS_PULL_REQUEST_BRANCH)
-#endif
+ifdef $(TRAVIS_PULL_REQUEST_BRANCH)
+ifneq ($(TRAVIS_PULL_REQUEST_BRANCH), "")
+	BRANCH = $(TRAVIS_PULL_REQUEST_BRANCH)
+endif
+endif
 
 flags=.makeFlags
 VPATH=$(flags)
@@ -32,6 +32,7 @@ clean:
 	rm -rf /tmp/server
 	rm -rf /tmp/authority
 	rm -rf $(flags)
+	mkdir $(flags)
 
 clean-data:
 	rm -rf ./ops/nonvoting_testnet/conf/provider?
@@ -72,7 +73,6 @@ push-geth:
 
 push-hashcloak-nonvoting-auth: build-hashcloak-nonvoting-authority
 	docker push '$(hashcloakAuth):$(BRANCH)'
-
 
 push-meson: build-meson
 	docker push '$(mesonServer):$(BRANCH)'

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ permits:
 	sudo chmod -R 700 ops/nonvoting_testnet/conf/auth
 	@touch $(flags)/$@
 
-up: permits build-meson build-hashcloak-nonvoting-authority up-nonvoting
+up: permits build-meson build-hashcloak-nonvoting-authority
 	GETH_IMAGE=$(gethImage) \
 	KATZEN_SERVER=$(katzenServer) \
 	KATZEN_AUTH=$(katzenAuth) \

--- a/ops/.dockerignore
+++ b/ops/.dockerignore
@@ -1,0 +1,1 @@
+./nonvoting_testnet

--- a/ops/auth.entry.sh
+++ b/ops/auth.entry.sh
@@ -76,6 +76,19 @@ if [[ ! -f $configFile ]]; then
   generateConfig
 else
   echo "Using exsiting config file at: $configFile"
+  dataDir=$(grep DataDir $configFile | grep -v \# | cut -d'=' -f2 | sed 's|"||g')
+fi
+
+publicKey=$dataDir/identity.private.pem
+privateKey=$dataDir/identity.private.pem
+cat $privateKey
+echo "$"
+ls $dataDir
+echo "$"
+
+if [[ ! -f $privateKey ]]; then
+  echo "No identity key files found. Generating new key files.."
+  /go/bin/nonvoting -f $configFile -g
 fi
 
 printf '

--- a/ops/auth.entry.sh
+++ b/ops/auth.entry.sh
@@ -5,15 +5,11 @@ dockerNetworkIP=$(ip addr show eth0 | grep inet | grep -v inet6 | cut -d' ' -f6 
 address="${ADDRESS:=$dockerNetworkIP}"
 configFile="${CONFIG_FILE:=/conf/authority.toml}"
 dataDir="${DATA_DIR:=/conf/data}"
-mkdir -p $dataDir
-chmod -R 700 $dataDir
-# Level specifies the log level out of `ERROR`, `WARNING`, `NOTICE`,
-# `INFO` and `DEBUG`.
+# logLevelValues can be: `ERROR`, `WARNING`, `NOTICE`, `INFO` and `DEBUG`.
 logLevel="${LOG_LEVEL:=ERROR}"
+logDir="${LOG_DIR:=/conf/logs}"
+logFile=$logDir/katzenpost.log
 disableLogging="${DISABLE_LOGS:=true}"
-logFile=$dataDir/katzenpost.log
-rm -f $logFile
-ln -s /dev/stdout $logFile
 
 function generateConfig {
   if [[ -z $MIX_KEYS ]]; then
@@ -73,14 +69,25 @@ EOF
 
 if [[ ! -f $configFile ]]; then
   echo "Generating config file..."
+  mkdir -p $dataDir
+  chmod -R 700 $dataDir
+  rm -f $logFile
+  ln -s /dev/stdout $logFile
   generateConfig
 else
   echo "Using exsiting config file at: $configFile"
 fi
 
-printf '\n\n\n\n'
+printf '
+########
+
+'
 echo "The public key of this node is:"
 echo $(cat ${dataDir}/identity.public.pem | grep -v PUBLIC)
-printf '\n\n\n\n'
+printf '
+
+
+########
+'
 
 exec /go/bin/nonvoting -f $configFile

--- a/ops/auth.entry.sh
+++ b/ops/auth.entry.sh
@@ -16,8 +16,8 @@ rm -f $logFile
 ln -s /dev/stdout $logFile
 
 function generateConfig {
-  if [[ -z $MIXERS ]]; then
-    echo "ERROR: Value MIXERS is not set."
+  if [[ -z $MIX_KEYS ]]; then
+    echo "ERROR: Value MIX_KEYS is not set."
     echo "Please set this value with the public keys of the mix nodes spaced with a comma"
     echo "example: key1,key2,key3...keyN"
     exit 1
@@ -63,7 +63,7 @@ EOF
 EOF
   done
 
-  for mix_id_key in $MIXERS; do
+  for mix_id_key in $MIX_KEYS; do
     cat - >> $configFile <<EOF
 [[Mixes]]
   IdentityKey = "${mix_id_key}"
@@ -77,5 +77,10 @@ if [[ ! -f $configFile ]]; then
 else
   echo "Using exsiting config file at: $configFile"
 fi
+
+printf '\n\n\n\n'
+echo "The public key of this node is:"
+echo $(cat ${dataDir}/identity.public.pem | grep -v PUBLIC)
+printf '\n\n\n\n'
 
 exec /go/bin/nonvoting -f $configFile

--- a/ops/auth.entry.sh
+++ b/ops/auth.entry.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+port="${PORT:=29483}"
+dockerNetworkIP=$(ip addr show eth0 | grep inet | grep -v inet6 | cut -d' ' -f6 | cut -d\/ -f1)
+address="${ADDRESS:=$dockerNetworkIP}"
+configFile="${CONFIG_FILE:=/conf/authority.toml}"
+dataDir="${DATA_DIR:=/conf/data}"
+mkdir -p $dataDir
+chmod -R 700 $dataDir
+
+# Level specifies the log level out of `ERROR`, `WARNING`, `NOTICE`,
+# `INFO` and `DEBUG`.
+logLevel="${LOG_LEVEL:=ERROR}"
+disableLogging="${DISABLE_LOGS:=true}"
+logFile=$dataDir/katzenpost.log
+
+ln -s /dev/stdout $logFile
+
+default="4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s=
+1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM=
+La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw="
+mixes="${MIXES:=$default}"
+
+default="provider1,2krwfNDfbakZCSTUUZYKXwdduzlEgS9Jfwm7eyZ0sCg=
+provider2,imigzI26tTRXyYLXujLEPI9QrNYOEgC4DElsFdP9acQ="
+providers="${PROVIDERS:=$default}"
+
+cat - > $configFile <<EOF
+# Katzenpost non-voting authority configuration file.
+[Authority]
+  Addresses = [ "${address}:${port}" ]
+  DataDir = "${dataDir}"
+
+[Logging]
+  Disable = ${disableLogging}
+  File = "${logFile}"
+  Level = "${logLevel}"
+
+[Debug]
+  MinNodesPerLayer = 1
+
+[Parameters]
+  SendRatePerMinute = 0
+  Mu = 0.001
+  MuMaxDelay = 90000
+  LambdaP = 0.0001234
+  LambdaPMaxDelay = 30000
+  LambdaL = 0.0001234
+  LambdaLMaxDelay = 30000
+  LambdaD = 0.0001234
+  LambdaDMaxDelay = 30000
+
+EOF
+
+for mix_id_key in $mixes; do
+cat - >> $configFile <<EOF
+[[Mixes]]
+  IdentityKey = "${mix_id_key}"
+
+EOF
+done
+
+for prov in $providers; do
+cat - >> $configFile <<EOF
+[[Providers]]
+  Identifier = "$(echo $prov | cut -d',' -f1)"
+  IdentityKey = "$(echo $prov | cut -d',' -f2)"
+
+EOF
+done
+
+
+cat - > ${dataDir}/identity.private.pem << EOF
+-----BEGIN ED25519 PRIVATE KEY-----
+bI4vCmWUlQOupW2Tr/rLbDjzDmE1kL5Qb7doaSpHOWKjjDU3KP+co3CGjlJZ8Ah+
+HtIxTwVHHnacwcaBiwwepA==
+-----END ED25519 PRIVATE KEY-----
+EOF
+
+
+cat - > ${dataDir}/identity.public.pem << EOF
+-----BEGIN ED25519 PUBLIC KEY-----
+o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+-----END ED25519 PUBLIC KEY-----
+EOF
+
+exec /go/bin/nonvoting -f $configFile

--- a/ops/auth.nonvoting.Dockerfile
+++ b/ops/auth.nonvoting.Dockerfile
@@ -1,0 +1,4 @@
+FROM %%KATZENPOST_AUTH%%
+RUN apk update --no-cache && apk add --no-cache bash
+ADD auth.entry.sh /entry.sh
+ENTRYPOINT /entry.sh

--- a/ops/dynamic-testnet.yml
+++ b/ops/dynamic-testnet.yml
@@ -27,6 +27,7 @@ services:
       - IS_PROVIDER=true
       - LOG_LEVEL=DEBUG
       - DISABLE_LOGS=false
+      - RPC_URL=https://g.sebas.tech
     depends_on:
       - auth
     networks:
@@ -45,7 +46,7 @@ services:
       - DISABLE_LOGS=false
       - SERVICE_TICKER=rin
       - CHAIN_ID=4
-      - RPC_URL=http://172.28.1.11:9545
+      - RPC_URL=https://rinkeby.sebas.tech
     depends_on:
       - auth
     networks:
@@ -98,27 +99,3 @@ services:
     networks:
       nonvoting_testnet:
         ipv4_address: 172.28.1.7
-  goerli:
-    image: ${GETH_IMAGE}
-    environment:
-      - "CHAIN=goerli"
-    volumes:
-      - /tmp/goerli:/blockchain
-    depends_on:
-      - provider1
-    networks:
-      nonvoting_testnet:
-        ipv4_address: 172.28.1.10
-
-  rinkeby:
-    image: ${GETH_IMAGE}
-    environment:
-      - "CHAIN=rinkeby"
-    volumes:
-      - /tmp/rinkeby:/blockchain
-    depends_on:
-      - provider2
-    networks:
-      nonvoting_testnet:
-        ipv4_address: 172.28.1.11
-

--- a/ops/dynamic-testnet.yml
+++ b/ops/dynamic-testnet.yml
@@ -1,0 +1,124 @@
+version: "3.7"
+
+networks:
+  nonvoting_testnet:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.1.0/24
+
+services:
+  auth:
+    restart: unless-stopped
+    image: ${AUTHORITY_IMAGE}
+    environment:
+      - DISABLE_LOGS=false
+      - LOG_LEVEL=DEBUG
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.2
+
+  provider1:
+    restart: unless-stopped
+    image: ${MESON_IMAGE}
+    environment:
+      - IDENTIFIER=provider1
+      - PORT=59483
+      - IS_PROVIDER=true
+      - LOG_LEVEL=DEBUG
+      - DISABLE_LOGS=false
+    depends_on:
+      - auth
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.3
+
+  provider2:
+    restart: unless-stopped
+    image: ${MESON_IMAGE}
+    environment:
+      - PORT=29484
+      - REGISTRATION_PORT=36967
+      - IDENTIFIER=provider2
+      - IS_PROVIDER=true
+      - LOG_LEVEL=DEBUG
+      - DISABLE_LOGS=false
+      - SERVICE_TICKER=rin
+      - CHAIN_ID=4
+      - RPC_URL=http://172.28.1.11:9545
+    depends_on:
+      - auth
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.4
+
+  mix1:
+    restart: unless-stopped
+    image: ${MESON_IMAGE}
+    environment:
+      - IDENTIFIER=mix1
+      - LOG_LEVEL=DEBUG
+      - DISABLE_LOGS=false
+    depends_on:
+      - auth
+      - provider1
+      - provider2
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.5
+
+  mix2:
+    restart: unless-stopped
+    image: ${MESON_IMAGE}
+    environment:
+      - IDENTIFIER=mix2
+      - PORT=29486
+      - LOG_LEVEL=DEBUG
+      - DISABLE_LOGS=false
+    depends_on:
+      - auth
+      - provider1
+      - provider2
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.6
+
+  mix3:
+    restart: unless-stopped
+    image: ${MESON_IMAGE}
+    environment:
+      - IDENTIFIER=mix3
+      - PORT=29487
+      - LOG_LEVEL=DEBUG
+      - DISABLE_LOGS=false
+    depends_on:
+      - auth
+      - provider1
+      - provider2
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.7
+  goerli:
+    image: ${GETH_IMAGE}
+    environment:
+      - "CHAIN=goerli"
+    volumes:
+      - /tmp/goerli:/blockchain
+    depends_on:
+      - provider1
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.10
+
+  rinkeby:
+    image: ${GETH_IMAGE}
+    environment:
+      - "CHAIN=rinkeby"
+    volumes:
+      - /tmp/rinkeby:/blockchain
+    depends_on:
+      - provider2
+    networks:
+      nonvoting_testnet:
+        ipv4_address: 172.28.1.11
+

--- a/ops/dynamic-testnet.yml
+++ b/ops/dynamic-testnet.yml
@@ -12,8 +12,13 @@ services:
     restart: unless-stopped
     image: ${AUTHORITY_IMAGE}
     environment:
+      - MIXERS=4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s=,1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM=,La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw=
+      - PROVIDERS=provider1:2krwfNDfbakZCSTUUZYKXwdduzlEgS9Jfwm7eyZ0sCg=,provider2:imigzI26tTRXyYLXujLEPI9QrNYOEgC4DElsFdP9acQ=
       - DISABLE_LOGS=false
       - LOG_LEVEL=DEBUG
+    volumes:
+      - ./nonvoting_testnet/conf/auth/authority_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/auth/authority_data/public.private.pem:/conf/data/identity.public.pem
     networks:
       nonvoting_testnet:
         ipv4_address: 172.28.1.2
@@ -22,12 +27,17 @@ services:
     restart: unless-stopped
     image: ${MESON_IMAGE}
     environment:
+      - AUTHORITY_KEY=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+      - AUTHORITY_ADDRESS=172.28.1.2:29483
       - IDENTIFIER=provider1
       - PORT=59483
       - IS_PROVIDER=true
       - LOG_LEVEL=DEBUG
       - DISABLE_LOGS=false
       - RPC_URL=https://g.sebas.tech
+    volumes:
+      - ./nonvoting_testnet/conf/provider1/provider_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/provider1/provider_data/public.private.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
     networks:
@@ -38,6 +48,8 @@ services:
     restart: unless-stopped
     image: ${MESON_IMAGE}
     environment:
+      - AUTHORITY_KEY=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+      - AUTHORITY_ADDRESS=172.28.1.2:29483
       - PORT=29484
       - REGISTRATION_PORT=36967
       - IDENTIFIER=provider2
@@ -47,6 +59,9 @@ services:
       - SERVICE_TICKER=rin
       - CHAIN_ID=4
       - RPC_URL=https://rinkeby.sebas.tech
+    volumes:
+      - ./nonvoting_testnet/conf/provider2/provider_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/provider2/provider_data/public.private.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
     networks:
@@ -57,9 +72,14 @@ services:
     restart: unless-stopped
     image: ${MESON_IMAGE}
     environment:
+      - AUTHORITY_KEY=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+      - AUTHORITY_ADDRESS=172.28.1.2:29483
       - IDENTIFIER=mix1
       - LOG_LEVEL=DEBUG
       - DISABLE_LOGS=false
+    volumes:
+      - ./nonvoting_testnet/conf/mix1/mix_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/mix1/mix_data/identity.public.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
       - provider1
@@ -72,10 +92,15 @@ services:
     restart: unless-stopped
     image: ${MESON_IMAGE}
     environment:
+      - AUTHORITY_KEY=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+      - AUTHORITY_ADDRESS=172.28.1.2:29483
       - IDENTIFIER=mix2
       - PORT=29486
       - LOG_LEVEL=DEBUG
       - DISABLE_LOGS=false
+    volumes:
+      - ./nonvoting_testnet/conf/mix2/mix_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/mix2/mix_data/identity.public.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
       - provider1
@@ -88,10 +113,15 @@ services:
     restart: unless-stopped
     image: ${MESON_IMAGE}
     environment:
+      - AUTHORITY_KEY=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=
+      - AUTHORITY_ADDRESS=172.28.1.2:29483
       - IDENTIFIER=mix3
       - PORT=29487
       - LOG_LEVEL=DEBUG
       - DISABLE_LOGS=false
+    volumes:
+      - ./nonvoting_testnet/conf/mix3/mix_data/identity.private.pem:/conf/data/identity.private.pem
+      - ./nonvoting_testnet/conf/mix3/mix_data/identity.public.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
       - provider1

--- a/ops/dynamic-testnet.yml
+++ b/ops/dynamic-testnet.yml
@@ -12,13 +12,13 @@ services:
     restart: unless-stopped
     image: ${AUTHORITY_IMAGE}
     environment:
-      - MIXERS=4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s=,1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM=,La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw=
+      - MIX_KEYS=4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s=,1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM=,La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw=
       - PROVIDERS=provider1:2krwfNDfbakZCSTUUZYKXwdduzlEgS9Jfwm7eyZ0sCg=,provider2:imigzI26tTRXyYLXujLEPI9QrNYOEgC4DElsFdP9acQ=
       - DISABLE_LOGS=false
       - LOG_LEVEL=DEBUG
     volumes:
       - ./nonvoting_testnet/conf/auth/authority_data/identity.private.pem:/conf/data/identity.private.pem
-      - ./nonvoting_testnet/conf/auth/authority_data/public.private.pem:/conf/data/identity.public.pem
+      - ./nonvoting_testnet/conf/auth/authority_data/identity.public.pem:/conf/data/identity.public.pem
     networks:
       nonvoting_testnet:
         ipv4_address: 172.28.1.2
@@ -37,7 +37,7 @@ services:
       - RPC_URL=https://g.sebas.tech
     volumes:
       - ./nonvoting_testnet/conf/provider1/provider_data/identity.private.pem:/conf/data/identity.private.pem
-      - ./nonvoting_testnet/conf/provider1/provider_data/public.private.pem:/conf/data/identity.public.pem
+      - ./nonvoting_testnet/conf/provider1/provider_data/identity.public.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
     networks:
@@ -61,7 +61,7 @@ services:
       - RPC_URL=https://rinkeby.sebas.tech
     volumes:
       - ./nonvoting_testnet/conf/provider2/provider_data/identity.private.pem:/conf/data/identity.private.pem
-      - ./nonvoting_testnet/conf/provider2/provider_data/public.private.pem:/conf/data/identity.public.pem
+      - ./nonvoting_testnet/conf/provider2/provider_data/identity.public.pem:/conf/data/identity.public.pem
     depends_on:
       - auth
     networks:

--- a/ops/meson.Dockerfile
+++ b/ops/meson.Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:alpine AS builder
+
+# Install git & make
+# Git is required for fetching the dependencies
+RUN apk update && \
+    apk add --no-cache git make ca-certificates && \
+    update-ca-certificates
+
+# Set the working directory for the container
+WORKDIR /go/Meson
+
+# Build the binary
+COPY ./plugin .
+RUN go build -o Meson cmd/main.go 
+
+FROM %%KATZEN_SERVER%%
+COPY --from=builder /go/Meson/Meson /go/bin/Meson
+RUN apk update --no-cache && apk add --no-cache bash
+ADD ./ops/meson.entry.sh /entry.sh
+ENTRYPOINT /entry.sh

--- a/ops/meson.entry.sh
+++ b/ops/meson.entry.sh
@@ -179,20 +179,20 @@ if [[ ! -f "$configFile" ]]; then
   else
     generateMixConfig
   fi
+  printf '
+  ########
+
+  '
+  echo "The public key of this node is:"
+  echo $(cat ${dataDir}/identity.public.pem | grep -v PUBLIC)
+  printf '
+
+
+  ########
+  '
 else
   echo "Using existing config file at: $configFile"
 fi
 
-printf '
-########
-
-'
-echo "The public key of this node is:"
-echo $(cat ${dataDir}/identity.public.pem | grep -v PUBLIC)
-printf '
-
-
-########
-'
 
 exec /go/bin/server -f $configFile

--- a/ops/meson.entry.sh
+++ b/ops/meson.entry.sh
@@ -119,7 +119,7 @@ EOF
 Ticker = "${service}"
 RPCUser = "rpcuser"
 RPCPass = "rpcpassword"
-RPCURL = "${rpcURL}"
+RPCURL = "${RPC_URL}"
 ChainId = ${chainID}
 LogDir = "${dataDir}"
 LogLevel = "${logLevel}"

--- a/ops/meson.entry.sh
+++ b/ops/meson.entry.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+set -e
+port="${PORT:=59484}"
+registrationPort="${REGISTRATION_PORT:=36968}"
+dockerNetworkIP=$(ip addr show eth0 | grep inet | grep -v inet6 | cut -d' ' -f6 | cut -d\/ -f1)
+address="${ADDRESS:=$dockerNetworkIP}"
+configFile="${CONFIG_FILE:=/conf/katzenpost.toml}"
+dataDir="${DATA_DIR:=/conf/data}"
+mkdir -p $dataDir
+chmod -R 700 $dataDir
+currencyFile="${CURRENCY_FILE:=/conf/currency.toml}"
+isProvider=${IS_PROVIDER:=false}
+authorityAddress="${AUTH_ADDRESS:=172.28.1.2:29483}"
+authorityPubKey="${AUTH_PUBK:=o4w1Nyj/nKNwho5SWfAIfh7SMU8FRx52nMHGgYsMHqQ=}"
+# logLevelValues can be: `ERROR`, `WARNING`, `NOTICE`, `INFO` and `DEBUG`.
+logLevel="${LOG_LEVEL:=ERROR}"
+disableLogging=${DISABLE_LOGS:=true}
+logFile=$dataDir/katzenpost.log
+ln -s /dev/stdout $logFile
+disableRateLimit=${DISABLE_RATE_LIM:=true}
+enableUserRegistrationHTTP=${ALLOW_HTTP_USER_REGISTRATION:=true}
+management=${ALLOW_MANAGEMENT:=false}
+service="${SERVICE_TICKER:=gor}"
+chainID="${CHAIN_ID:=5}"
+rpcURL="${RPC_URL:=http://172.28.1.10:9545}"
+plugins="${PLUGINS:=echo panda memspool}"
+
+
+
+if $isProvider; then
+echo "Setting up provider"
+cat - > $configFile <<EOF
+# Katzenpost server configuration file.
+[Server]
+  Identifier = "${IDENTIFIER}"
+  Addresses = [ "${address}:${port}"]
+  DataDir = "${dataDir}"
+  IsProvider = ${isProvider}
+
+[PKI]
+  [PKI.Nonvoting]
+    Address = "${authorityAddress}"
+    PublicKey = "${authorityPubKey}"
+
+[Logging]
+  Disable = ${disableLogging}
+  File = "${logFile}"
+  Level = "${logLevel}"
+
+[Debug]
+  DisableRateLimit = ${disableRateLimit}
+
+[Provider]
+EnableUserRegistrationHTTP = ${enableUserRegistrationHTTP}
+UserRegistrationHTTPAddresses = ["${address}:${registrationPort}"]
+AdvertiseUserRegistrationHTTPAddresses = ["http://${address}:${registrationPort}"]
+
+[Management]
+  Enable = ${management}
+
+[[Provider.Kaetzchen]]
+    Disable = false
+    Capability = "loop"
+    Endpoint = "+loop"
+
+  [[Provider.CBORPluginKaetzchen]]
+    Disable = false
+    Capability = "${service}"
+    Endpoint = "+${service}"
+    Command = "/go/bin/Meson"
+    MaxConcurrency = 1
+    [Provider.CBORPluginKaetzchen.Config]
+      log_dir = "${dataDir}"
+      log_level = "${logLevel}"
+      f = "$currencyFile"
+EOF
+
+if [[ $plugins == *"echo"* ]]; then
+cat - >> $configFile <<EOF
+   [[Provider.CBORPluginKaetzchen]]
+     Disable = false
+     Capability = "echo"
+     Endpoint = "+echo"
+     Command = "/go/bin/echo_server"
+     MaxConcurrency = 1
+     [Provider.CBORPluginKaetzchen.Config]
+      log_dir = "${dataDir}"
+      log_level = "${logLevel}"
+EOF
+fi
+
+if [[ $plugins == *"panda"* ]]; then
+cat - >> $configFile <<EOF
+   [[Provider.CBORPluginKaetzchen]]
+     Disable = false
+     Capability = "panda"
+     Endpoint = "+panda"
+     Command = "/go/bin/panda_server"
+     MaxConcurrency = 1
+     [Provider.CBORPluginKaetzchen.Config]
+      log_dir = "${dataDir}"
+      log_level = "${logLevel}"
+      fileStore = "${dataDir}/panda.storage"
+EOF
+fi
+
+if [[ $plugins == *"memspool"* ]]; then
+cat - >> $configFile <<EOF
+  [[Provider.CBORPluginKaetzchen]]
+    Disable = false
+    Capability = "spool"
+    Endpoint = "+spool"
+    Command = "/go/bin/memspool"
+    MaxConcurrency = 1
+    [Provider.CBORPluginKaetzchen.Config]
+      data_store = "${dataDir}/memspool.storage"
+      log_dir = "${dataDir}"
+EOF
+fi
+
+cat - > $currencyFile <<EOF
+Ticker = "${service}"
+RPCUser = "rpcuser"
+RPCPass = "rpcpassword"
+RPCURL = "${rpcURL}"
+ChainId = ${chainID}
+LogDir = "${dataDir}"
+LogLevel = "${logLevel}"
+EOF
+
+else
+echo "Setting up mix"
+cat - > $configFile <<EOF
+# Katzenpost server configuration file.
+[Server]
+  Identifier = "${IDENTIFIER}"
+  Addresses = [ "${address}:${port}"]
+  DataDir = "${dataDir}"
+  IsProvider = ${isProvider}
+
+[PKI]
+  [PKI.Nonvoting]
+    Address = "${authorityAddress}"
+    PublicKey = "${authorityPubKey}"
+
+[Logging]
+  Disable = ${disableLogging}
+  File = "${logFile}"
+  Level = "${logLevel}"
+EOF
+fi
+
+if [ ${IDENTIFIER} == "mix1" ]; then
+pk='-----BEGIN ED25519 PRIVATE KEY-----
+LGH1LpJqJAG+Hg1wV6oMgYtQ838xZS9vRwjQ0B0kybfiv2N48Bu7OHK1yczedsPl
+RA6bOXVfWEjxA4xuFOuDyw==
+-----END ED25519 PRIVATE KEY-----'
+pub='-----BEGIN ED25519 PUBLIC KEY-----
+4r9jePAbuzhytcnM3nbD5UQOmzl1X1hI8QOMbhTrg8s=
+-----END ED25519 PUBLIC KEY-----'
+link='-----BEGIN X25519 PRIVATE KEY-----
+Xv4PJ6gPCJEvuLVQ7dsUMT21KnASz4O82CyJhpCPoXg=
+-----END X25519 PRIVATE KEY-----'
+fi
+
+
+if [ ${IDENTIFIER} == "mix2" ]; then
+pk='-----BEGIN ED25519 PRIVATE KEY-----
+ApYndNBRTyY5Peu9sO7fQiZphU04Kepp3ai+dFXDdrLXHy2rTiFj6Lzej1ifaet9
+OQWPiNcgxYJaKVHt+CtbIw==
+-----END ED25519 PRIVATE KEY-----'
+pub='-----BEGIN ED25519 PUBLIC KEY-----
+1x8tq04hY+i83o9Yn2nrfTkFj4jXIMWCWilR7fgrWyM=
+-----END ED25519 PUBLIC KEY-----'
+link='-----BEGIN X25519 PRIVATE KEY-----
+MpTalIlC0SqMEWvgqiohvu18vfxxq6Rm5cTVZBFE9eY=
+-----END X25519 PRIVATE KEY-----'
+fi
+
+if [ ${IDENTIFIER} == "mix3" ]; then
+pk='-----BEGIN ED25519 PRIVATE KEY-----
+olXV48urFRPjucBUbvZ1i8bDGQozzyaazDndya9OmiAtrYWexsqhTx3NCF83jOTF
+JifpPstFaYWfQmC2USSVDA==
+-----END ED25519 PRIVATE KEY-----'
+pub='-----BEGIN ED25519 PUBLIC KEY-----
+La2FnsbKoU8dzQhfN4zkxSYn6T7LRWmFn0JgtlEklQw=
+-----END ED25519 PUBLIC KEY-----'
+link='-----BEGIN X25519 PRIVATE KEY-----
+87rDmtVXd1DW3eqh6Zfs+ICrRu0YT2Rx8CuRs9sIfCE=
+-----END X25519 PRIVATE KEY-----'
+fi
+
+
+if [ ${IDENTIFIER} == "provider1" ]; then
+pk='-----BEGIN ED25519 PRIVATE KEY-----
+ndkH4sYkxVXPFU7OF6wryVar5cWxsZEBcFXWOHnEM3/aSvB80N9tqRkJJNRRlgpf
+B127OUSBL0l/Cbt7JnSwKA==
+-----END ED25519 PRIVATE KEY-----'
+pub='-----BEGIN ED25519 PUBLIC KEY-----
+2krwfNDfbakZCSTUUZYKXwdduzlEgS9Jfwm7eyZ0sCg=
+-----END ED25519 PUBLIC KEY-----'
+link='-----BEGIN X25519 PRIVATE KEY-----
+iboFtIVykmdzQoL3rDha5Vs0RtxfmQJT8CyWRbT09Xg=
+-----END X25519 PRIVATE KEY-----'
+fi
+
+if [ ${IDENTIFIER} == "provider2" ]; then
+pk='-----BEGIN ED25519 PRIVATE KEY-----
+xun4XQfdsh+w8pD+e1Rml9RCaOTfCoZHG3s6OOek9v2KaKDMjbq1NFfJgte6MsQ8
+j1Cs1g4SALgMSWwV0/1pxA==
+-----END ED25519 PRIVATE KEY-----'
+pub='-----BEGIN ED25519 PUBLIC KEY-----
+imigzI26tTRXyYLXujLEPI9QrNYOEgC4DElsFdP9acQ=
+-----END ED25519 PUBLIC KEY-----'
+link='-----BEGIN X25519 PRIVATE KEY-----
+04XSX85Ov4jDTb0vqEMv3McYME7weayniGLKtmF6UwQ=
+-----END X25519 PRIVATE KEY-----'
+fi
+
+cat - > ${dataDir}/identity.private.pem << EOF
+${pk}
+EOF
+
+cat - > ${dataDir}/identity.public.pem << EOF
+${pub}
+EOF
+
+cat - > ${dataDir}/link.private.pem << EOF
+${link}
+EOF
+
+exec /go/bin/server -f $configFile

--- a/ops/meson.entry.sh
+++ b/ops/meson.entry.sh
@@ -22,7 +22,7 @@ enableUserRegistrationHTTP=${ALLOW_HTTP_USER_REGISTRATION:=true}
 management=${ALLOW_MANAGEMENT:=false}
 service="${SERVICE_TICKER:=gor}"
 chainID="${CHAIN_ID:=5}"
-rpcURL="${RPC_URL:=http://172.28.1.10:9545}"
+rpcURL="${RPC_URL:=https://g.sebas.tech}"
 plugins="${PLUGINS:=echo panda memspool}"
 
 


### PR DESCRIPTION
This PR closes #27 #47.

This PR makes the containers more modular by generating the config files through ENVIRONMENT variables  the config files are generate during the container startup or you can also reference. This makes the containers less dependent on the docker compose hard coded values to coordinate between the nodes and instead just needs environments variables to be set when running the container. These environments variables can later be changed to command line flags to avoid the awkward syntax of using environment variables.

Changes:
- Config files can be generate from the command line flags or from mounting an existing config file into the right path. Currently the default path is `
- New `dynamic-compose.yml` that makes use of the environment variables. It also doesn't use geth nodes
- Added one additional container image: `hashcloak/authority`.
- The log files go to `/dev/stdout`
- The `hashcloak/provider` contains both the config files for being a provider or a mix node.

TODO:
- [ ] Provide instructions on how to use the containers in standalone manner.
- [x] Need to improve the logic on how required environment variables are checked.
- [ ] Make sure that the original `docker-compose` works well for local dev work without the need of the environment variables or the too fancy docker scripts.
- [ ] ~~Make sure all log files go to `/dev/stdout`~~ This is going to be harder to implement because the plugins use a `log_dir` instead of a `log_file`.