### PR TITLE
Update .travis.yml deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ script:
 deploy:
   - provider: script
     script:
-      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-      - make push
+      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && make push
     on:
       branch: master
 


### PR DESCRIPTION
Travis doesn't allow for arrays to be in the script key of deploy.

You can see here a broken config:

https://travis-ci.org/sebohe/Meson/jobs/634021009/config Line 21

and a working config:
https://travis-ci.org/sebohe/Meson/jobs/634045948/config?utm_medium=notification&utm_source=github_status Line 21