### PR TITLE
Enable katzenmint prometheus stats

### DIFF
--- a/testnet/local/conf/monitoring/prometheus.yaml
+++ b/testnet/local/conf/monitoring/prometheus.yaml
@@ -7,10 +7,16 @@ rule_files:
   # - "second.rules"
 
 scrape_configs:
-  #- job_name: prometheus
-  #  static_configs:
-  #    - targets: ['localhost:9090']
   - job_name: meson-server
     static_configs:
+      - targets: [mix1:6543]
+      - targets: [mix2:6543]
+      - targets: [mix3:6543]
       - targets: [provider1:6543]
       - targets: [provider2:6543]
+  - job_name: katzenmint
+    static_configs:
+      - targets: [auth1:26660]
+      - targets: [auth2:26660]
+      - targets: [auth3:26660]
+      - targets: [auth4:26660]

--- a/testnet/local/conf/node1/config/config.toml
+++ b/testnet/local/conf/node1/config/config.toml
@@ -378,7 +378,7 @@ indexer = "kv"
 # When true, Prometheus metrics are served under /metrics on
 # PrometheusListenAddr.
 # Check out the documentation for the list of available metrics.
-prometheus = false
+prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
 prometheus_listen_addr = ":26660"
@@ -390,4 +390,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "tendermint"
+namespace = "katzenmint"

--- a/testnet/local/conf/node2/config/config.toml
+++ b/testnet/local/conf/node2/config/config.toml
@@ -378,7 +378,7 @@ indexer = "kv"
 # When true, Prometheus metrics are served under /metrics on
 # PrometheusListenAddr.
 # Check out the documentation for the list of available metrics.
-prometheus = false
+prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
 prometheus_listen_addr = ":26660"
@@ -390,4 +390,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "tendermint"
+namespace = "katzenmint"

--- a/testnet/local/conf/node3/config/config.toml
+++ b/testnet/local/conf/node3/config/config.toml
@@ -378,7 +378,7 @@ indexer = "kv"
 # When true, Prometheus metrics are served under /metrics on
 # PrometheusListenAddr.
 # Check out the documentation for the list of available metrics.
-prometheus = false
+prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
 prometheus_listen_addr = ":26660"
@@ -390,4 +390,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "tendermint"
+namespace = "katzenmint"

--- a/testnet/local/conf/node4/config/config.toml
+++ b/testnet/local/conf/node4/config/config.toml
@@ -378,7 +378,7 @@ indexer = "kv"
 # When true, Prometheus metrics are served under /metrics on
 # PrometheusListenAddr.
 # Check out the documentation for the list of available metrics.
-prometheus = false
+prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
 prometheus_listen_addr = ":26660"
@@ -390,4 +390,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "tendermint"
+namespace = "katzenmint"

--- a/testnet/local/docker-compose.yml
+++ b/testnet/local/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     ports:
       - "127.0.0.1:30001:30001"
       - "127.0.0.1:40001:40001"
-      - "127.0.0.1:6543:6543"
     depends_on:
       auth1:
         condition: service_healthy
@@ -181,6 +180,16 @@ services:
       - ./conf/monitoring/prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
+    depends_on:
+      - auth1
+      - auth2
+      - auth3
+      - auth4
+      - provider1
+      - provider2
+      - mix1
+      - mix2
+      - mix3
     healthcheck:
       test: ["CMD", "wget", "-O", "-", "http://localhost:9090"]
       interval: 10s
@@ -194,6 +203,16 @@ services:
     image: grafana/grafana:8.4.3
     ports:
       - 3000:3000
+    depends_on:
+      - auth1
+      - auth2
+      - auth3
+      - auth4
+      - provider1
+      - provider2
+      - mix1
+      - mix2
+      - mix3
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.129


### PR DESCRIPTION
In this PR, enable katzenmint prometheus stats for local testnet.