### PR TITLE
installation: check whether user is root when install

### DIFF
--- a/katzenmint/install.sh
+++ b/katzenmint/install.sh
@@ -277,6 +277,15 @@ hash_sha256_verify() {
     return 1
   fi
 }
+root_check() {
+	if [ "$EUID" -eq 0 ]; then
+		echo "Do you want to install with root user (y/n)?"
+		read installAsRoot
+		if [ "$installAsRoot" = "n" ]; then
+			exit 0
+		fi
+	fi
+}
 cat /dev/null <<EOF
 ------------------------------------------------------------------------
 End of functions from https://github.com/client9/shlib
@@ -292,6 +301,8 @@ ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"
 PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+
+root_check
 
 uname_os_check "$OS"
 uname_arch_check "$ARCH"

--- a/server/install.sh
+++ b/server/install.sh
@@ -277,6 +277,15 @@ hash_sha256_verify() {
     return 1
   fi
 }
+root_check() {
+	if [ "$EUID" -eq 0 ]; then
+		echo "Do you want to install with root user (y/n)?"
+		read installAsRoot
+		if [ "$installAsRoot" = "n" ]; then
+			exit 0
+		fi
+	fi
+}
 cat /dev/null <<EOF
 ------------------------------------------------------------------------
 End of functions from https://github.com/client9/shlib
@@ -292,6 +301,8 @@ ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"
 PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+
+root_check
 
 uname_os_check "$OS"
 uname_arch_check "$ARCH"


### PR DESCRIPTION
# Description

Check whether user is root when install.

Related issue: https://github.com/hashcloak/Meson/issues/151

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

