### PR TITLE
katzenmint: unify errors

### DIFF
--- a/katzenmint/app.go
+++ b/katzenmint/app.go
@@ -185,7 +185,12 @@ func (app *KatzenmintApplication) CheckTx(req abcitypes.RequestCheckTx) abcitype
 func (app *KatzenmintApplication) Commit() abcitypes.ResponseCommit {
 	appHash, err := app.state.Commit()
 	if err != nil {
-		app.logger.Error("commit failed", "epoch", app.state.currentEpoch, "height", app.state.blockHeight, "error", err)
+		// swallow insufficient descriptot / provier error
+		if err == errDocInsufficientDescriptor || err == errDocInsufficientProvider {
+			app.logger.Debug("insufficient error", "epoch", app.state.currentEpoch, "height", app.state.blockHeight, "error", err)
+		} else {
+			app.logger.Error("commit failed", "epoch", app.state.currentEpoch, "height", app.state.blockHeight, "error", err)
+		}
 	}
 	return abcitypes.ResponseCommit{Data: appHash}
 }

--- a/katzenmint/app.go
+++ b/katzenmint/app.go
@@ -185,7 +185,7 @@ func (app *KatzenmintApplication) CheckTx(req abcitypes.RequestCheckTx) abcitype
 func (app *KatzenmintApplication) Commit() abcitypes.ResponseCommit {
 	appHash, err := app.state.Commit()
 	if err != nil {
-		// swallow insufficient descriptot / provier error
+		// swallow insufficient descriptor / provider error
 		if err == errDocInsufficientDescriptor || err == errDocInsufficientProvider {
 			app.logger.Debug("insufficient error", "epoch", app.state.currentEpoch, "height", app.state.blockHeight, "error", err)
 		} else {

--- a/katzenmint/config/config.go
+++ b/katzenmint/config/config.go
@@ -31,6 +31,7 @@ const (
 	absoluteMaxDelay            = 6 * 60 * 60 * 1000 // 6 hours.
 )
 
+// TODO: do we need to cap the default value of LambdaP/LambdaL/LambdaD/LambdaM max delay?
 var DefaultParameters = katconfig.Parameters{
 	SendRatePerMinute: defaultSendRatePerMinute,
 	Mu:                defaultMu,
@@ -81,31 +82,31 @@ func (c *Config) FixupAndValidate() (err error) {
 	if c.Parameters.Mu <= 0 {
 		c.Parameters.Mu = DefaultParameters.Mu
 	}
-	if c.Parameters.MuMaxDelay <= 0 {
+	if c.Parameters.MuMaxDelay <= 0 || c.Parameters.MuMaxDelay > absoluteMaxDelay {
 		c.Parameters.MuMaxDelay = DefaultParameters.MuMaxDelay
 	}
 	if c.Parameters.LambdaP <= 0 {
 		c.Parameters.LambdaP = DefaultParameters.LambdaP
 	}
-	if c.Parameters.LambdaPMaxDelay <= 0 {
+	if c.Parameters.LambdaPMaxDelay <= 0 || c.Parameters.LambdaPMaxDelay > absoluteMaxDelay {
 		c.Parameters.LambdaPMaxDelay = DefaultParameters.LambdaPMaxDelay
 	}
 	if c.Parameters.LambdaL <= 0 {
 		c.Parameters.LambdaL = DefaultParameters.LambdaL
 	}
-	if c.Parameters.LambdaLMaxDelay <= 0 {
+	if c.Parameters.LambdaLMaxDelay <= 0 || c.Parameters.LambdaLMaxDelay > absoluteMaxDelay {
 		c.Parameters.LambdaLMaxDelay = DefaultParameters.LambdaLMaxDelay
 	}
 	if c.Parameters.LambdaD <= 0 {
 		c.Parameters.LambdaD = DefaultParameters.LambdaD
 	}
-	if c.Parameters.LambdaDMaxDelay <= 0 {
+	if c.Parameters.LambdaDMaxDelay <= 0 || c.Parameters.LambdaDMaxDelay > absoluteMaxDelay {
 		c.Parameters.LambdaDMaxDelay = DefaultParameters.LambdaDMaxDelay
 	}
 	if c.Parameters.LambdaM <= 0 {
 		c.Parameters.LambdaM = DefaultParameters.LambdaM
 	}
-	if c.Parameters.LambdaMMaxDelay <= 0 {
+	if c.Parameters.LambdaMMaxDelay <= 0 || c.Parameters.LambdaMMaxDelay > absoluteMaxDelay {
 		c.Parameters.LambdaMMaxDelay = DefaultParameters.LambdaMMaxDelay
 	}
 	return
@@ -120,7 +121,7 @@ func Load(b []byte) (*Config, error) {
 		return nil, err
 	}
 	if undecoded := md.Undecoded(); len(undecoded) != 0 {
-		return nil, fmt.Errorf("config: Undecoded keys in config file: %v", undecoded)
+		return nil, fmt.Errorf("undecoded keys in config file (%v)", undecoded)
 	}
 	if err := cfg.FixupAndValidate(); err != nil {
 		return nil, err

--- a/katzenmint/state.go
+++ b/katzenmint/state.go
@@ -72,15 +72,15 @@ type KatzenmintState struct {
 func NewKatzenmintState(kConfig *config.Config, db dbm.DB, dbCacheSize int) *KatzenmintState {
 	tree, err := iavl.NewMutableTree(db, dbCacheSize, true)
 	if err != nil {
-		panic(fmt.Errorf("error creating iavl tree"))
+		panic(fmt.Errorf("failed to create iavl tree: %v", err))
 	}
 	version, err := tree.Load()
 	if err != nil {
-		panic(fmt.Errorf("error loading iavl tree: %v", err))
+		panic(fmt.Errorf("failed to load iavl tree: %v", err))
 	}
 	appHash, err := tree.Hash()
 	if err != nil {
-		panic(fmt.Errorf("error loading iavl tree hash: %v", err))
+		panic(fmt.Errorf("failed to load iavl tree hash: %v", err))
 	}
 	state := &KatzenmintState{
 		tree:             tree,
@@ -93,13 +93,13 @@ func NewKatzenmintState(kConfig *config.Config, db dbm.DB, dbCacheSize int) *Kat
 	}
 	epochInfoValue, err := state.tree.Get([]byte(epochInfoKey))
 	if err != nil {
-		panic(fmt.Errorf("error get value"))
+		panic(fmt.Errorf("failed to get epoch %s: %v", epochInfoKey, err))
 	}
 	if version == 0 {
 		state.currentEpoch = GenesisEpoch
 		state.epochStartHeight = state.blockHeight
 	} else if epochInfoValue == nil || len(epochInfoValue) != 16 {
-		panic("error loading the current epoch number and its starting height")
+		panic(fmt.Errorf("failed to load the current epoch number and its starting height (%x)", epochInfoValue))
 	} else {
 		state.currentEpoch, _ = binary.Uvarint(epochInfoValue[:8])
 		state.epochStartHeight, _ = binary.Varint(epochInfoValue[8:])
@@ -107,7 +107,7 @@ func NewKatzenmintState(kConfig *config.Config, db dbm.DB, dbCacheSize int) *Kat
 	keyDoc := storageKey(documentsBucket, []byte{}, state.currentEpoch-1)
 	rawDoc, err := state.tree.Get(keyDoc)
 	if err != nil {
-		panic(fmt.Errorf("error get value"))
+		panic(fmt.Errorf("failed to get document (%d): %v", state.currentEpoch-1, err))
 	}
 	state.prevDocument, _ = s11n.VerifyAndParseDocument(rawDoc)
 	return state
@@ -199,15 +199,15 @@ func (state *KatzenmintState) updateMixDescriptor(rawDesc []byte, desc *pki.MixD
 
 	// Check for redundant uploads.
 	if _, err := state.get(key); err == nil {
-		return fmt.Errorf("duplicated descriptor with key %s for epoch %d", EncodeHex(desc.IdentityKey.Bytes()), epoch)
+		return fmt.Errorf("duplicated descriptor with key (%x) for epoch (%d)", desc.IdentityKey.Bytes(), epoch)
 	}
 
 	// Check for epoch
 	if epoch < state.currentEpoch {
-		return fmt.Errorf("late descriptor upload with key %s for epoch %d", EncodeHex(desc.IdentityKey.Bytes()), epoch)
+		return fmt.Errorf("late descriptor upload with key (%x) for epoch (%d)", desc.IdentityKey.Bytes(), epoch)
 	}
 	if epoch >= state.currentEpoch+uint64(LifeCycle) {
-		return fmt.Errorf("early descriptor upload with key %s for epoch %d", EncodeHex(desc.IdentityKey.Bytes()), epoch)
+		return fmt.Errorf("early descriptor upload with key (%x) for epoch (%d)", desc.IdentityKey.Bytes(), epoch)
 	}
 
 	// Save it to memory db.
@@ -219,7 +219,7 @@ func (state *KatzenmintState) updateAuthority(rawAuth []byte, v abcitypes.Valida
 
 	pubkey, err := cryptoenc.PubKeyFromProto(v.PubKey)
 	if err != nil {
-		return fmt.Errorf("can't decode public key: %w", err)
+		return fmt.Errorf("can't decode public key: %v", err)
 	}
 	key := storageKey(authoritiesBucket, pubkey.Address(), 0)
 
@@ -292,7 +292,7 @@ func (state *KatzenmintState) get(key []byte) (val []byte, err error) {
 	} else {
 		val, err = state.tree.Get(key)
 		if err != nil || val == nil {
-			return nil, fmt.Errorf("key '%v' does not exist", key)
+			return nil, fmt.Errorf("key (%v) does not exist", key)
 		}
 	}
 	ret := make([]byte, len(val))
@@ -346,7 +346,7 @@ func (state *KatzenmintState) GetEpoch(height int64) ([]byte, *ics23.CommitmentP
 		return nil, nil, err
 	}
 	if len(val) != 16 {
-		return nil, nil, fmt.Errorf("error fetching latest epoch for height %v", height)
+		return nil, nil, fmt.Errorf("failed to fetching latest epoch for height (%v)", height)
 	}
 	return val, proof, nil
 }
@@ -370,7 +370,7 @@ func (state *KatzenmintState) GetDocument(epoch uint64, height int64) ([]byte, *
 		if epoch == state.currentEpoch {
 			return nil, nil, ErrQueryDocumentNotReady
 		}
-		return nil, nil, fmt.Errorf("requesting document for a too future epoch %d", epoch)
+		return nil, nil, fmt.Errorf("requesting document for a too future epoch (%d)", epoch)
 	}
 	return doc, proof, nil
 }
@@ -452,7 +452,7 @@ func (s *KatzenmintState) generateDocument() (*document, error) {
 		return nil, fmt.Errorf("signed document failed validation: %v", err)
 	}
 	if pDoc.Epoch != s.currentEpoch {
-		return nil, fmt.Errorf("signed document has invalid epoch: %v", pDoc.Epoch)
+		return nil, fmt.Errorf("signed document has invalid epoch (%v)", pDoc.Epoch)
 	}
 	ret := &document{
 		doc: pDoc,

--- a/katzenmint/state.go
+++ b/katzenmint/state.go
@@ -165,11 +165,7 @@ func (state *KatzenmintState) Commit() ([]byte, error) {
 		return nil, errSave
 	}
 	state.appHash = appHash
-
-	// Mute the error if keeps occuring
-	if err == state.prevCommitError {
-		err = nil
-	} else {
+	if err != state.prevCommitError {
 		state.prevCommitError = err
 	}
 	return appHash, err


### PR DESCRIPTION
# Description

This PR aims to unify errors used in katzenmint.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

`
make test
`


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

