### PR TITLE
katzenmint: add show-node-id

### DIFF
--- a/katzenmint/cmd/katzenmint/run.go
+++ b/katzenmint/cmd/katzenmint/run.go
@@ -109,6 +109,7 @@ func init() {
 	runCmd.Flags().IntVar(&dbCacheSize, "dbcachesize", 100, "Cache size for katzenmint db")
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(registerValidatorCmd)
+	rootCmd.AddCommand(showNodeIDCmd)
 }
 
 func initConfig() (kConfig *kcfg.Config, config *cfg.Config, err error) {

--- a/katzenmint/cmd/katzenmint/showNodeId.go
+++ b/katzenmint/cmd/katzenmint/showNodeId.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/p2p"
+)
+
+var (
+	showNodeIDCmd = &cobra.Command{
+		Use:   "show-node-id",
+		Short: "Show p2p id of the node",
+		RunE:  showNodeID,
+	}
+)
+
+func showNodeID(cmd *cobra.Command, args []string) error {
+	_, config, err := initConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %v\n", err)
+	}
+	nodeKey, err := p2p.LoadNodeKey(config.NodeKeyFile())
+	if err != nil {
+		return err
+	}
+	fmt.Println(nodeKey.ID())
+	return nil
+}


### PR DESCRIPTION
# Description

When I setup different validator settings and persistent seed information, I found the p2p id is in node key file. I saw `show-node-id` in tendermint. In this PR, I migrate `show-node-id` into katzenmint.

> There are some other useful commands in `tendermint`, we might think a way to integrate easily.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

