### PR TITLE
katzenmint: patch nil dereference of exist proof

### DIFF
--- a/katzenmint/app.go
+++ b/katzenmint/app.go
@@ -234,13 +234,15 @@ func (app *KatzenmintApplication) Query(rquery abcitypes.RequestQuery) (resQuery
 			return
 		}
 		existProof := proof.GetExist()
-		if existProof != nil {
-			op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
-			resQuery.Key = existProof.Key
-			resQuery.Value = val
-			resQuery.ProofOps = &tmcrypto.ProofOps{
-				Ops: []tmcrypto.ProofOp{op.ProofOp()},
-			}
+		if existProof == nil {
+			parseErrorResponse(ErrQueryEpochFailed, &resQuery)
+			return
+		}
+		op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
+		resQuery.Key = existProof.Key
+		resQuery.Value = val
+		resQuery.ProofOps = &tmcrypto.ProofOps{
+			Ops: []tmcrypto.ProofOp{op.ProofOp()},
 		}
 
 	case GetConsensus:
@@ -260,13 +262,15 @@ func (app *KatzenmintApplication) Query(rquery abcitypes.RequestQuery) (resQuery
 			return
 		}
 		existProof := proof.GetExist()
-		if existProof != nil {
-			op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
-			resQuery.Key = existProof.Key
-			resQuery.Value = doc
-			resQuery.ProofOps = &tmcrypto.ProofOps{
-				Ops: []tmcrypto.ProofOp{op.ProofOp()},
-			}
+		if existProof == nil {
+			parseErrorResponse(ErrQueryDocumentUnknown, &resQuery)
+			return
+		}
+		op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
+		resQuery.Key = existProof.Key
+		resQuery.Value = doc
+		resQuery.ProofOps = &tmcrypto.ProofOps{
+			Ops: []tmcrypto.ProofOp{op.ProofOp()},
 		}
 	}
 	return

--- a/katzenmint/app.go
+++ b/katzenmint/app.go
@@ -233,12 +233,14 @@ func (app *KatzenmintApplication) Query(rquery abcitypes.RequestQuery) (resQuery
 			}
 			return
 		}
-		exist := proof.GetExist()
-		op := costypes.NewIavlCommitmentOp(exist.Key, proof)
-		resQuery.Key = exist.Key
-		resQuery.Value = val
-		resQuery.ProofOps = &tmcrypto.ProofOps{
-			Ops: []tmcrypto.ProofOp{op.ProofOp()},
+		existProof := proof.GetExist()
+		if existProof != nil {
+			op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
+			resQuery.Key = existProof.Key
+			resQuery.Value = val
+			resQuery.ProofOps = &tmcrypto.ProofOps{
+				Ops: []tmcrypto.ProofOp{op.ProofOp()},
+			}
 		}
 
 	case GetConsensus:
@@ -257,12 +259,14 @@ func (app *KatzenmintApplication) Query(rquery abcitypes.RequestQuery) (resQuery
 			}
 			return
 		}
-		exist := proof.GetExist()
-		op := costypes.NewIavlCommitmentOp(exist.Key, proof)
-		resQuery.Key = exist.Key
-		resQuery.Value = doc
-		resQuery.ProofOps = &tmcrypto.ProofOps{
-			Ops: []tmcrypto.ProofOp{op.ProofOp()},
+		existProof := proof.GetExist()
+		if existProof != nil {
+			op := costypes.NewIavlCommitmentOp(existProof.Key, proof)
+			resQuery.Key = existProof.Key
+			resQuery.Value = doc
+			resQuery.ProofOps = &tmcrypto.ProofOps{
+				Ops: []tmcrypto.ProofOp{op.ProofOp()},
+			}
 		}
 	}
 	return

--- a/katzenmint/state.go
+++ b/katzenmint/state.go
@@ -310,7 +310,11 @@ func (state *KatzenmintState) getProof(key []byte, height int64) ([]byte, *ics23
 	if err != nil {
 		return nil, nil, err
 	}
-	return proof.GetExist().Value, proof, err
+	existProof := proof.GetExist()
+	if existProof == nil {
+		return nil, nil, fmt.Errorf("proof (%v) not found at (%d)", key, height)
+	}
+	return existProof.Value, proof, err
 }
 
 func (state *KatzenmintState) set(key []byte, value []byte) error {


### PR DESCRIPTION
# Description

I saw nil dereference of proof somehow. This issue was fixed in this PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

