### PR TITLE
ping: use defer

### DIFF
--- a/ping/main.go
+++ b/ping/main.go
@@ -54,6 +54,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer c.Shutdown()
 
 	s, err := c.NewSession(linkKey)
 	if err != nil {
@@ -75,6 +76,4 @@ func main() {
 		panic(err)
 	}
 	fmt.Printf("Return: %s\n", payload)
-
-	c.Shutdown()
 }


### PR DESCRIPTION
# Description

The client won't close if error happen (panic). In this PR, I use defer to close connection.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

