### PR TITLE
katzenmint: rename katzenmint_db to katzenmint

### DIFF
--- a/client/client.toml
+++ b/client/client.toml
@@ -15,7 +15,7 @@
     ChainID = "test-chain-QvpdAC"
     PrimaryAddress = "tcp://127.0.0.1:26657"
     WitnessesAddresses = ["tcp://127.0.0.1:26657"]
-    DatabaseName = "test_meson_server_pkiclient_db"
+    DatabaseName = "test_meson_server_pkiclient"
     DatabaseDir = "/tmp/meson_server/server_data"
     RPCAddress = "tcp://127.0.0.1:26657"
 

--- a/katzenmint/cmd/katzenmint/run.go
+++ b/katzenmint/cmd/katzenmint/run.go
@@ -126,7 +126,7 @@ func runNode(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
-	db, err := dbm.NewDB("katzenmint_db", dbm.GoLevelDBBackend, kConfig.DBPath)
+	db, err := dbm.NewDB("katzenmint", dbm.GoLevelDBBackend, kConfig.DBPath)
 	if err != nil {
 		return fmt.Errorf("failed to open badger db: %v\ntry running with -tags badgerdb", err)
 	}

--- a/server/cmd/meson-server/katzenpost.toml.sample
+++ b/server/cmd/meson-server/katzenpost.toml.sample
@@ -40,7 +40,7 @@
     ChainID = "katzenmint-chain-71DRoz"
     PrimaryAddress = "tcp://127.0.0.1:21483"
     WitnessesAddresses = [ "127.0.0.1:21483" ]
-    DatabaseName = "test_meson_server_pkiclient_db"
+    DatabaseName = "test_meson_server_pkiclient"
     DatabaseDir = "/tmp/meson_server/server_data"
     RPCAddress = "tcp://127.0.0.1:21483"
 

--- a/server/config/server.toml
+++ b/server/config/server.toml
@@ -40,7 +40,7 @@
     ChainID = "katzenmint-chain-71DRoz"
     PrimaryAddress = "tcp://104.131.108.194:26657"
     WitnessesAddresses = [ "165.227.158.164:26657", "165.227.90.185:26657", "104.131.108.194:26657" ]
-    DatabaseName = "pkiclient_db"
+    DatabaseName = "pkiclient"
     DatabaseDir = "/tmp/meson_server/server_data"
     RPCAddress = "tcp://104.131.108.194:26657"
 


### PR DESCRIPTION
# Description

Tendermint already suffix `.db`, won't be necessary to use `_db` in default name. Also it's might weird for the name like `katzenmint_db.db`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

