### PR TITLE
Build images automatically if not exists

### DIFF
--- a/testnet/local/README.md
+++ b/testnet/local/README.md
@@ -1,25 +1,14 @@
 # Docker
 This docker-compose configuration is meant to be used in combination with the [Meson server](https://github.com/hashcloak/Meson/tree/monorepo/server) and [Katzenmint PKI](https://github.com/hashcloak/Meson/tree/monorepo/katzenmint) repositories. It is meant for testing client and server mix network components as part of the core Meson developer work flow. It should be obvious that this docker-compose situation is not meant for production use.
 
-1. clone meson server and build docker image of meson server
+1. start four katzenmint pki nodes / three mix nodes / two providers.
 ```BASH
-$ git clone https://github.com/hashcloak/Meson.git
-$ cd Meson/server
-$ docker build --no-cache -t meson/server .
-```
-
-2. build docker image for katzenmint
-```BASH
-$ cd Meson/katzenmint
-$ docker build --no-cache -t katzenmint/pki .
-```
-
-3. start four katzenmint pki nodes / three mix nodes / two providers.
-```BASH
+$ cd testnet/local/
+$ docker-compose build
 $ docker-compose up
 ```
 
-4. checkout information of katzenmint pki nodes with curl command
+2. checkout information of katzenmint pki nodes with curl command
 ```BASH
 # node1
 $ curl http://127.0.0.1:21483/net_info

--- a/testnet/local/docker-compose.yml
+++ b/testnet/local/docker-compose.yml
@@ -5,6 +5,9 @@ services:
   provider1:
     restart: unless-stopped
     image: meson/server
+    build:
+      context: ../../
+      dockerfile: Dockerfile.server
     volumes:
       - ./conf/provider1:/conf
       - ./scripts:/scripts
@@ -28,6 +31,9 @@ services:
   provider2:
     restart: unless-stopped
     image: meson/server
+    build:
+      context: ../../
+      dockerfile: Dockerfile.server
     volumes:
       - ./conf/provider2:/conf
       - ./scripts:/scripts
@@ -51,6 +57,9 @@ services:
   mix1:
     restart: unless-stopped
     image: meson/server
+    build:
+      context: ../../
+      dockerfile: Dockerfile.server
     volumes:
       - ./conf/mix1:/conf
       - ./scripts:/scripts
@@ -72,6 +81,9 @@ services:
   mix2:
     restart: unless-stopped
     image: meson/server
+    build:
+      context: ../../
+      dockerfile: Dockerfile.server
     volumes:
       - ./conf/mix2:/conf
       - ./scripts:/scripts
@@ -93,6 +105,9 @@ services:
   mix3:
     restart: unless-stopped
     image: meson/server
+    build:
+      context: ../../
+      dockerfile: Dockerfile.server
     volumes:
       - ./conf/mix3:/conf
       - ./scripts:/scripts
@@ -114,6 +129,9 @@ services:
   auth1:
     restart: unless-stopped
     image: katzenmint/pki
+    build:
+      context: ../../
+      dockerfile: Dockerfile.katzenmint
     volumes:
       - ./conf/node1:/chain
     healthcheck:
@@ -130,6 +148,9 @@ services:
   auth2:
     restart: unless-stopped
     image: katzenmint/pki
+    build:
+      context: ../../
+      dockerfile: Dockerfile.katzenmint
     volumes:
       - ./conf/node2:/chain
     healthcheck:
@@ -145,6 +166,9 @@ services:
   auth3:
     restart: unless-stopped
     image: katzenmint/pki
+    build:
+      context: ../../
+      dockerfile: Dockerfile.katzenmint
     volumes:
       - ./conf/node3:/chain
     healthcheck:
@@ -161,6 +185,9 @@ services:
   auth4:
     restart: unless-stopped
     image: katzenmint/pki
+    build:
+      context: ../../
+      dockerfile: Dockerfile.katzenmint
     volumes:
       - ./conf/node4:/chain
     healthcheck:


### PR DESCRIPTION
# Description

Supporting automatically build the docker images if the `meson/server` or `katzenmint/pki` does not exist.

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

