### PR TITLE
use template

### DIFF
--- a/Dockerfile.katzenmint
+++ b/Dockerfile.katzenmint
@@ -24,4 +24,7 @@ COPY --from=builder /go/Meson/katzenmint/katzenmint /go/bin/katzenmint
 
 VOLUME /chain
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 \
+    CMD curl -f http://localhost:26657/block_results?height=1 || exit 1
+
 ENTRYPOINT /go/bin/katzenmint run --config /chain/katzenmint.toml

--- a/testnet/local/docker-compose.yml
+++ b/testnet/local/docker-compose.yml
@@ -38,11 +38,6 @@ x-auth: &auth
   build:
     context: ../../
     dockerfile: Dockerfile.katzenmint
-  healthcheck:
-    test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
-    interval: 10s
-    timeout: 10s
-    retries: 10
 
 services:
   provider1:

--- a/testnet/local/docker-compose.yml
+++ b/testnet/local/docker-compose.yml
@@ -1,144 +1,114 @@
 version: "2"
 
-services:
+x-provider: &provider
+  restart: unless-stopped
+  image: meson/server
+  build:
+    context: ../../
+    dockerfile: Dockerfile.server
+  entrypoint: ash /scripts/entrypoint.sh
+  depends_on:
+    auth1:
+      condition: service_healthy
+    auth2:
+      condition: service_healthy
+    auth3:
+      condition: service_healthy
+    auth4:
+      condition: service_healthy
 
+x-mix: &mix
+  restart: unless-stopped
+  image: meson/server
+  build:
+    context: ../../
+    dockerfile: Dockerfile.server
+  entrypoint: ash /scripts/entrypoint.sh
+  depends_on:
+    - auth1
+    - auth2
+    - auth3
+    - auth4
+    - provider1
+    - provider2
+
+x-auth: &auth
+  restart: unless-stopped
+  image: katzenmint/pki
+  build:
+    context: ../../
+    dockerfile: Dockerfile.katzenmint
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
+    interval: 10s
+    timeout: 10s
+    retries: 10
+
+services:
   provider1:
-    restart: unless-stopped
-    image: meson/server
-    build:
-      context: ../../
-      dockerfile: Dockerfile.server
+    <<: *provider
     volumes:
       - ./conf/provider1:/conf
       - ./scripts:/scripts
-    entrypoint: ash /scripts/entrypoint.sh
     ports:
       - "127.0.0.1:30001:30001"
       - "127.0.0.1:40001:40001"
-    depends_on:
-      auth1:
-        condition: service_healthy
-      auth2:
-        condition: service_healthy
-      auth3:
-        condition: service_healthy
-      auth4:
-        condition: service_healthy
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.2
 
   provider2:
-    restart: unless-stopped
-    image: meson/server
-    build:
-      context: ../../
-      dockerfile: Dockerfile.server
+    <<: *provider
     volumes:
       - ./conf/provider2:/conf
       - ./scripts:/scripts
-    entrypoint: ash /scripts/entrypoint.sh
     ports:
       - "127.0.0.1:30002:30002"
       - "127.0.0.1:40002:40002"
-    depends_on:
-      auth1:
-        condition: service_healthy
-      auth2:
-        condition: service_healthy
-      auth3:
-        condition: service_healthy
-      auth4:
-        condition: service_healthy
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.3
 
   mix1:
-    restart: unless-stopped
-    image: meson/server
-    build:
-      context: ../../
-      dockerfile: Dockerfile.server
+    <<: *mix
     volumes:
       - ./conf/mix1:/conf
       - ./scripts:/scripts
-    entrypoint: ash /scripts/entrypoint.sh
     ports:
       - "127.0.0.1:30004:30004"
       - "127.0.0.1:40004:40004"
-    depends_on:
-      - auth1
-      - auth2
-      - auth3
-      - auth4
-      - provider1
-      - provider2
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.4
 
   mix2:
-    restart: unless-stopped
-    image: meson/server
-    build:
-      context: ../../
-      dockerfile: Dockerfile.server
+    <<: *mix
     volumes:
       - ./conf/mix2:/conf
       - ./scripts:/scripts
-    entrypoint: ash /scripts/entrypoint.sh
     ports:
       - "127.0.0.1:30005:30005"
       - "127.0.0.1:40005:40005"
-    depends_on:
-      - auth1
-      - auth2
-      - auth3
-      - auth4
-      - provider1
-      - provider2
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.5
 
   mix3:
-    restart: unless-stopped
-    image: meson/server
-    build:
-      context: ../../
-      dockerfile: Dockerfile.server
+    <<: *mix
     volumes:
       - ./conf/mix3:/conf
       - ./scripts:/scripts
-    entrypoint: ash /scripts/entrypoint.sh
     ports:
       - "127.0.0.1:30006:30006"
       - "127.0.0.1:40006:40006"
-    depends_on:
-      - auth1
-      - auth2
-      - auth3
-      - auth4
-      - provider1
-      - provider2
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.6
 
   auth1:
-    restart: unless-stopped
-    image: katzenmint/pki
-    build:
-      context: ../../
-      dockerfile: Dockerfile.katzenmint
+    <<: *auth
     volumes:
       - ./conf/node1:/chain
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
     ports:
       - "127.0.0.1:21483:26657"
     networks:
@@ -146,36 +116,19 @@ services:
         ipv4_address: 172.29.1.7
 
   auth2:
-    restart: unless-stopped
-    image: katzenmint/pki
-    build:
-      context: ../../
-      dockerfile: Dockerfile.katzenmint
+    <<: *auth
     volumes:
       - ./conf/node2:/chain
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
     ports:
       - "127.0.0.1:21484:26657"
     networks:
       katzenmint_net:
         ipv4_address: 172.29.1.8
+
   auth3:
-    restart: unless-stopped
-    image: katzenmint/pki
-    build:
-      context: ../../
-      dockerfile: Dockerfile.katzenmint
+    <<: *auth
     volumes:
       - ./conf/node3:/chain
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
     ports:
       - "127.0.0.1:21485:26657"
     networks:
@@ -183,18 +136,9 @@ services:
         ipv4_address: 172.29.1.9
 
   auth4:
-    restart: unless-stopped
-    image: katzenmint/pki
-    build:
-      context: ../../
-      dockerfile: Dockerfile.katzenmint
+    <<: *auth
     volumes:
       - ./conf/node4:/chain
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:26657/block_results?height=1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
     ports:
       - "127.0.0.1:21486:26657"
     networks:


### PR DESCRIPTION
# Description

docker-compose.yml has many re-use content for replica instance like `auth-1` `mix-1`.
So aggrecate same keys to template for readability.

## Type of change


# How Has This Been Tested?


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

