### PR TITLE
plugin: add bitcoin

### DIFF
--- a/plugin/pkg/chain/bitcoin_chain.go
+++ b/plugin/pkg/chain/bitcoin_chain.go
@@ -8,20 +8,6 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-// An bitcoin request abstraction.
-// Only need it for one method, though.
-type btcRequest struct {
-	ID uint `json:"id"`
-	// Indicates which version of JSON RPC to use
-	// Since all networks support JSON RPC 2.0,
-	// this attribute is a constant
-	JSONRPC string `json:"jsonrpc"`
-	// Which method you want to call
-	METHOD string `json:"method"`
-	// Params for the method you want to call
-	Params interface{} `json:"params"`
-}
-
 // BTCChain is a struct for identifier blockchains and their forks
 type BTCChain struct {
 	testnet bool
@@ -42,7 +28,7 @@ func (ec *BTCChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		marshalledRequest, err = json.Marshal(btcRequest{
+		marshalledRequest, err = json.Marshal(jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "sendrawtransaction",
@@ -59,7 +45,7 @@ func (ec *BTCChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		marshalledRequest, err = json.Marshal(btcRequest{
+		marshalledRequest, err = json.Marshal(jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "getrawtransaction",
@@ -76,7 +62,7 @@ func (ec *BTCChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		marshalledRequest, err = json.Marshal(btcRequest{
+		marshalledRequest, err = json.Marshal(jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "listunspent",

--- a/plugin/pkg/chain/bitcoin_chain.go
+++ b/plugin/pkg/chain/bitcoin_chain.go
@@ -1,0 +1,132 @@
+package chain
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashcloak/Meson/plugin/pkg/command"
+	"github.com/ugorji/go/codec"
+)
+
+// An bitcoin request abstraction.
+// Only need it for one method, though.
+type btcRequest struct {
+	ID uint `json:"id"`
+	// Indicates which version of JSON RPC to use
+	// Since all networks support JSON RPC 2.0,
+	// this attribute is a constant
+	JSONRPC string `json:"jsonrpc"`
+	// Which method you want to call
+	METHOD string `json:"method"`
+	// Params for the method you want to call
+	Params interface{} `json:"params"`
+}
+
+// BTCChain is a struct for identifier blockchains and their forks
+type BTCChain struct {
+	testnet bool
+	ticker  string
+}
+
+func (ec *BTCChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*HttpData, error) {
+	if len(rpcURL) == 0 {
+		return nil, fmt.Errorf("non existent RPC URL for Bitcoin chain")
+	}
+
+	var marshalledRequest []byte
+	switch cmd {
+	case command.PostTransaction:
+		var req command.PostTransactionRequest
+		dec := codec.NewDecoderBytes(payload, &jsonHandle)
+		err := dec.Decode(&req)
+		if err != nil {
+			return nil, err
+		}
+		marshalledRequest, err = json.Marshal(btcRequest{
+			ID:      1,
+			JSONRPC: "2.0",
+			METHOD:  "sendrawtransaction",
+			Params:  []string{req.TxHex},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+	case command.BtcQueryTransaction:
+		var req command.BtcQueryTransactionRequest
+		dec := codec.NewDecoderBytes(payload, &jsonHandle)
+		err := dec.Decode(&req)
+		if err != nil {
+			return nil, err
+		}
+		marshalledRequest, err = json.Marshal(btcRequest{
+			ID:      1,
+			JSONRPC: "2.0",
+			METHOD:  "getrawtransaction",
+			Params:  []string{req.TxHash},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+	case command.BtcQuery:
+		var req command.BtcQueryRequest
+		dec := codec.NewDecoderBytes(payload, &jsonHandle)
+		err := dec.Decode(&req)
+		if err != nil {
+			return nil, err
+		}
+		marshalledRequest, err = json.Marshal(btcRequest{
+			ID:      1,
+			JSONRPC: "2.0",
+			METHOD:  "listunspent",
+			Params:  []string{fmt.Sprintf("0x%x", req.Min), fmt.Sprintf("0x%x", req.Max), req.Target},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, fmt.Errorf("invalid cmd %x for bitcoin chain", cmd)
+	}
+
+	if marshalledRequest == nil {
+		return nil, fmt.Errorf("unexpected error when wrapping request")
+	}
+	return &HttpData{Method: "POST", URL: rpcURL, Body: marshalledRequest}, nil
+}
+
+func (ec *BTCChain) UnwrapResponse(cmd uint8, payload []RPCResponse) ([]byte, error) {
+	// Check if response type is error
+	for _, pl := range payload {
+		if pl.Error != nil {
+			return nil, errCodeAndMsg(pl.Error.Code, pl.Error.Message)
+		}
+	}
+
+	// Command-wise processing
+	switch cmd {
+	case command.PostTransaction:
+		if len(payload) != 1 {
+			return nil, errNumResponse(1, len(payload))
+		}
+		return json.Marshal(command.PostTransactionResponse{
+			TxHash: payload[0].Result,
+		})
+	case command.BtcQueryTransaction:
+		if len(payload) != 1 {
+			return nil, errNumResponse(1, len(payload))
+		}
+		return json.Marshal(command.BtcQueryTransactionResponse{
+			Tx: payload[0].Result,
+		})
+	case command.BtcQuery:
+		if len(payload) != 1 {
+			return nil, errNumResponse(1, len(payload))
+		}
+		return json.Marshal(command.BtcQueryResponse{
+			Utxo: payload[0].Result,
+		})
+	}
+	return nil, fmt.Errorf("unexpected error when unwrapping response")
+}

--- a/plugin/pkg/chain/chain_test.go
+++ b/plugin/pkg/chain/chain_test.go
@@ -145,3 +145,16 @@ func TestCosmosChainURL(t *testing.T) {
 		t.Fatalf("URL should have value %s, got %s", broadcastTxAsync, getRequest.URL)
 	}
 }
+
+func TestBTCChainURL(t *testing.T) {
+	chainInterface, _ := GetChain("BTC")
+	expectedURL := "EXPECTED_URL"
+	req, _ := json.Marshal(command.PostTransactionRequest{TxHex: ""})
+	postRequest, err := chainInterface.WrapRequest(expectedURL, command.PostTransaction, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if postRequest.Method != "POST" {
+		t.Fatalf("Expected %s, got %s", "POST", postRequest.Method)
+	}
+}

--- a/plugin/pkg/chain/chain_test.go
+++ b/plugin/pkg/chain/chain_test.go
@@ -72,7 +72,7 @@ func TestEthereumChainTxnInBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var gotValue ethRequest
+	var gotValue jsonrpcRequest
 	err = json.Unmarshal(postRequest.Body, &gotValue)
 	if err != nil {
 		t.Fatalf("err unmarshal: %v\n", err)

--- a/plugin/pkg/chain/ethereum_chain.go
+++ b/plugin/pkg/chain/ethereum_chain.go
@@ -8,21 +8,6 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-// An ethereum request abstraction.
-// Only need it for one method, though.
-type ethRequest struct {
-	// ChainId to indicate which Ethereum-based network
-	ID uint `json:"id"`
-	// Indicates which version of JSON RPC to use
-	// Since all networks support JSON RPC 2.0,
-	// this attribute is a constant
-	JSONRPC string `json:"jsonrpc"`
-	// Which method you want to call
-	METHOD string `json:"method"`
-	// Params for the method you want to call
-	Params interface{} `json:"params"`
-}
-
 // ETHChain is a struct for identifier blockchains and their forks
 type ETHChain struct {
 	chainID uint
@@ -43,7 +28,7 @@ func (ec *ETHChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		marshalledRequest, err = json.Marshal(ethRequest{
+		marshalledRequest, err = json.Marshal(jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "eth_sendRawTransaction",
@@ -60,18 +45,18 @@ func (ec *ETHChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		blockNumberRequest := ethRequest{
+		blockNumberRequest := jsonrpcRequest{
 			ID:      2,
 			JSONRPC: "2.0",
 			METHOD:  "eth_blockNumber",
 		}
-		receiptRequest := ethRequest{
+		receiptRequest := jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "eth_getTransactionReceipt",
 			Params:  []string{req.TxHash},
 		}
-		marshalledRequest, err = json.Marshal([]ethRequest{
+		marshalledRequest, err = json.Marshal([]jsonrpcRequest{
 			blockNumberRequest,
 			receiptRequest,
 		})
@@ -86,13 +71,13 @@ func (ec *ETHChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if err != nil {
 			return nil, err
 		}
-		nonceRequest := ethRequest{
+		nonceRequest := jsonrpcRequest{
 			ID:      1,
 			JSONRPC: "2.0",
 			METHOD:  "eth_getTransactionCount",
 			Params:  []string{req.From, "pending"},
 		}
-		gasPriceRequest := ethRequest{
+		gasPriceRequest := jsonrpcRequest{
 			ID:      2,
 			JSONRPC: "2.0",
 			METHOD:  "eth_gasPrice",
@@ -105,19 +90,19 @@ func (ec *ETHChain) WrapRequest(rpcURL string, cmd uint8, payload []byte) (*Http
 		if req.Data != "" {
 			param["data"] = req.Data
 		}
-		gasEstimateRequest := ethRequest{
+		gasEstimateRequest := jsonrpcRequest{
 			ID:      3,
 			JSONRPC: "2.0",
 			METHOD:  "eth_estimateGas",
 			Params:  []interface{}{param},
 		}
-		ethCallRequest := ethRequest{
+		ethCallRequest := jsonrpcRequest{
 			ID:      3,
 			JSONRPC: "2.0",
 			METHOD:  "eth_call",
 			Params:  []interface{}{param, "latest"},
 		}
-		marshalledRequest, err = json.Marshal([]ethRequest{
+		marshalledRequest, err = json.Marshal([]jsonrpcRequest{
 			nonceRequest,
 			gasPriceRequest,
 			gasEstimateRequest,

--- a/plugin/pkg/chain/factory.go
+++ b/plugin/pkg/chain/factory.go
@@ -39,6 +39,10 @@ func GetChain(ticker string) (IChain, error) {
 		return &ETHChain{ticker: "TOPT", chainID: 69}, nil
 	case "OPT":
 		return &ETHChain{ticker: "OPT", chainID: 10}, nil
+	case "BTC":
+		return &BTCChain{ticker: "BTC", testnet: false}, nil
+	case "TBTC":
+		return &BTCChain{ticker: "BTC", testnet: true}, nil
 	default:
 		return nil, fmt.Errorf("unsupported chain")
 	}

--- a/plugin/pkg/chain/jsonrpc.go
+++ b/plugin/pkg/chain/jsonrpc.go
@@ -1,0 +1,14 @@
+package chain
+
+// An json request abstraction.
+type jsonrpcRequest struct {
+	ID uint `json:"id"`
+	// Indicates which version of JSON RPC to use
+	// Since all networks support JSON RPC 2.0, 1.0
+	// this attribute is a constant
+	JSONRPC string `json:"jsonrpc"`
+	// Which method you want to call
+	METHOD string `json:"method"`
+	// Params for the method you want to call
+	Params interface{} `json:"params"`
+}

--- a/plugin/pkg/command/bitcoin.go
+++ b/plugin/pkg/command/bitcoin.go
@@ -1,0 +1,28 @@
+package command
+
+import "math/big"
+
+const (
+	BtcQuery            uint8 = 0x20
+	BtcQueryTransaction uint8 = 0x21
+)
+
+// Request Types
+type BtcQueryRequest struct {
+	Min    *big.Int
+	Max    *big.Int
+	Target string
+}
+
+type BtcQueryTransactionRequest struct {
+	TxHash string
+}
+
+// Response Types
+type BtcQueryResponse struct {
+	Utxo string
+}
+
+type BtcQueryTransactionResponse struct {
+	Tx string
+}


### PR DESCRIPTION
# Description

In this PR, I added bitcoin rpcs to plugin. With this feature, user can send bitcoin transactions through Meson.

Note:
- It might be better to add bitcoin example in meson wallet demo.
- It didn't support all rpcs in bitcoin (https://developer.bitcoin.org/reference/rpc/).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

