### PR TITLE
update local provider RPC

### DIFF
--- a/testnet/local/conf/provider1/currency.toml
+++ b/testnet/local/conf/provider1/currency.toml
@@ -3,7 +3,3 @@ LogLevel = "DEBUG"
 
 [RPC.gor]
   Url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
-[RPC.rin]
-  Url = "https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
-[RPC.kov]
-  Url = "https://kovan.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"

--- a/testnet/local/conf/provider2/currency.toml
+++ b/testnet/local/conf/provider2/currency.toml
@@ -3,7 +3,3 @@ LogLevel = "DEBUG"
 
 [RPC.gor]
   Url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
-[RPC.rin]
-  Url = "https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
-[RPC.kov]
-  Url = "https://kovan.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"


### PR DESCRIPTION
# Description

Update currency.toml in local test net provider to match [#190](https://github.com/hashcloak/Meson/pull/190), fixing test net error due to missing rpc ticker.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that any new log messages doesn't inavertedly link compromising information to an external observer about the Meson Mixnet.

